### PR TITLE
Build container image with github actions

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,0 +1,85 @@
+name: Build Container Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+    # Local registry needed to share the build-env image between steps when
+    # using the docker-container buildkit driver
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v4
+
+      - name: Gather information
+        id: info
+        run: |
+          echo "toolchain_version=$(yq '.toolchain.channel' --output-format=yaml rust-toolchain.toml)" >> $GITHUB_OUTPUT
+          echo "crate_version=$(yq '.package.version' --output-format=yaml Cargo.toml)" >> $GITHUB_OUTPUT
+          echo "git_timestamp=$(git log -1 --pretty=%ct)" >> $GITHUB_OUTPUT
+
+          echo "## Build information" >> $GITHUB_STEP_SUMMARY
+          echo "|     |     |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          cat $GITHUB_OUTPUT | sed 's/\(.*\)=\(.*\)/| \1 | \2 |/' >> $GITHUB_STEP_SUMMARY
+
+      - uses: docker/setup-buildx-action@v3
+        with:
+          # network=host driver-opt needed to push to local registry
+          driver-opts: network=host
+
+      - name: Prepare build environment image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./build/build-image
+          build-args: RUST_TOOLCHAIN=${{ steps.info.outputs.toolchain_version }}
+          cache-from: type=gha,scope=build-env
+          cache-to: type=gha,mode=max,scope=build-env
+          push: true
+          tags: localhost:5000/build-env:latest
+
+      - name: Gather image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/embarkstudios/quilkin
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=${{ steps.info.outputs.crate_version }}-
+
+      - name: Build container image
+        uses: docker/build-push-action@v6
+        with:
+          # build.rs runs git commands, need to preserve .git directory
+          # https://docs.docker.com/reference/dockerfile/#buildkit-built-in-build-args
+          build-args: BUILDKIT_CONTEXT_KEEP_GIT_DIR=1
+          file: image/Dockerfile.ghaction
+          build-contexts: |
+            build-env=docker-image://localhost:5000/build-env:latest
+          cache-from: type=gha,scope=quilkin
+          cache-to: type=gha,mode=max,scope=quilkin
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+        env:
+          # Set the build timestamp to the commit timestamp, so we can
+          # hopefully get reproducible builds when built from the same commit
+          # https://github.com/moby/buildkit/blob/master/docs/build-repro.md#source_date_epoch
+          SOURCE_DATE_EPOCH: ${{ steps.info.outputs.git_timestamp }}

--- a/image/Dockerfile.ghaction
+++ b/image/Dockerfile.ghaction
@@ -1,0 +1,17 @@
+FROM build-env AS builder
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/bin/x86_64-linux-gnu-gcc
+COPY . /workspace
+WORKDIR /workspace
+RUN cargo about generate license.html.hbs > license.html
+RUN cargo run -p proto-gen -- generate
+RUN cargo build --profile=lto --target x86_64-unknown-linux-gnu
+RUN ./image/archive_dependencies.sh
+
+FROM gcr.io/distroless/cc-debian12:nonroot AS base
+WORKDIR /
+COPY --from=builder /workspace/license.html .
+COPY --from=builder /workspace/dependencies-src.zip .
+COPY --from=builder --chown=nonroot:nonroot /workspace/target/x86_64-unknown-linux-gnu/lto/quilkin .
+
+USER nonroot:nonroot
+ENTRYPOINT ["/quilkin"]


### PR DESCRIPTION
Just the bare minimum to build the same container image that we got from cloud build via a github action and push it to `ghcr.io/embarkstudios/quilkin`. I've bypassed `build/Makefile` entirely and only picked out the relevant steps, but leaving all the old stuff as is for now. I created a new `Dockerfile.ghaction` that runs some of the old make targets in a dockerfile multi stage build instead as that works better with `docker/build-push-action`.

The `build-env` image is not saved in a remote registry but should be cached between runs in the gha cache.

The action should now run on
* any push to main
* any new tag (without `/` in the name)
* triggering the workflow manually (can't test this until the workflow is on main)

One image pushed so far: https://github.com/EmbarkStudios/quilkin/pkgs/container/quilkin, same size as the last cloud  build image and still has the commit sha embedded in the binary.