### PR TITLE
Ensure Datacenter xDS resource names and versions are consistent

### DIFF
--- a/crates/xds/src/client.rs
+++ b/crates/xds/src/client.rs
@@ -620,6 +620,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
             let mut stream = stream;
             let mut resource_subscriptions = resource_subscriptions;
 
+            is_healthy.store(true, Ordering::SeqCst);
             loop {
                 tracing::info!(%control_plane, "creating discovery response handler");
                 let mut response_stream = crate::config::handle_delta_discovery_responses(
@@ -638,8 +639,6 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
 
                     match next_response.await {
                         Ok(Some(Ok(response))) => {
-                            is_healthy.store(true, Ordering::SeqCst);
-
                             let node_id = if let Some(node) = &response.node {
                                 node.id.clone()
                             } else {
@@ -721,6 +720,7 @@ pub async fn delta_subscribe<C: crate::config::Configuration>(
                     return Err(error.wrap_err("refresh failed"));
                 }
                 tracing::info!(%control_plane, "xDS connection refreshed");
+                is_healthy.store(true, Ordering::SeqCst);
             }
         }
         .instrument(tracing::trace_span!("xds_client_stream", client_id)),


### PR DESCRIPTION
Because we were using different values for `XdsResource.name` and the first parameter to the `client_state.version_matches()` call we would always think that the version does not match and push an update.

Also make sure we check the version when propagating self.

This exposed a bug where if the relay restarts, a proxy would get stuck in unhealthy because the xDS client would only move back to healthy if it received an update, but since the unnecessary updates were removed we would not get one if nothing had changed.