### PR TITLE
Initial corrosion gossip pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ source = "git+https://github.com/aya-rs/aya?rev=2453204#2453204a9b07a3a92d538f7c
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.17.1",
  "libc",
  "log",
@@ -515,12 +515,6 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -817,7 +811,7 @@ dependencies = [
 [[package]]
 name = "consul-client"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "camino",
  "http",
@@ -870,7 +864,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "corro-api-types"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "camino",
  "compact_str",
@@ -889,7 +883,7 @@ dependencies = [
 [[package]]
 name = "corro-base-types"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "camino",
  "compact_str",
@@ -909,7 +903,7 @@ dependencies = [
 [[package]]
 name = "corro-types"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "antithesis_sdk",
  "arc-swap",
@@ -958,14 +952,14 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tripwire",
- "uhlc 0.7.0",
+ "uhlc",
  "uuid",
 ]
 
 [[package]]
 name = "corro-utils"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "eyre",
  "tokio",
@@ -997,7 +991,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tripwire",
- "uhlc 0.9.0",
+ "uhlc",
  "uuid",
 ]
 
@@ -1121,7 +1115,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -1252,46 +1246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
-]
-
-[[package]]
-name = "defmt"
-version = "0.3.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
-dependencies = [
- "defmt 1.1.1",
-]
-
-[[package]]
-name = "defmt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
-dependencies = [
- "defmt-parser",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2414,7 +2368,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "inotify-sys",
  "libc",
 ]
@@ -2465,7 +2419,7 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -2752,7 +2706,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "libc",
 ]
 
@@ -3257,7 +3211,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cfg-if",
  "libc",
 ]
@@ -3319,7 +3273,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3337,7 +3291,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -3929,7 +3883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -4129,7 +4083,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tripwire",
- "uhlc 0.9.0",
+ "uhlc",
  "uuid",
 ]
 
@@ -4425,7 +4379,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -4474,7 +4428,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -4627,7 +4581,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -4691,7 +4645,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4859,7 +4813,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5122,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "spawn"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "futures",
  "parking_lot",
@@ -5159,12 +5113,6 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
-
-[[package]]
-name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
@@ -5181,7 +5129,7 @@ dependencies = [
 [[package]]
 name = "sqlite-functions"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -5190,7 +5138,7 @@ dependencies = [
 [[package]]
 name = "sqlite-pool"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "arc-swap",
  "deadpool",
@@ -5219,7 +5167,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9add252f9b70a7d493b03127524ed06cdf7480b3dc8c1b2ccfda89384d90a8b7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cc",
  "fallible-iterator",
  "indexmap",
@@ -5364,7 +5312,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5697,7 +5645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64",
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
@@ -5847,7 +5795,7 @@ dependencies = [
 [[package]]
 name = "tripwire"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
 dependencies = [
  "futures",
  "futures-util",
@@ -5923,27 +5871,15 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uhlc"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b6df3f3e948b40e20c38a6d1fd6d8f91b3573922fc164e068ad3331560487e"
-dependencies = [
- "defmt 0.3.100",
- "humantime",
- "lazy_static",
- "log",
- "rand 0.8.6",
- "serde",
- "spin 0.9.9",
-]
-
-[[package]]
-name = "uhlc"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55bb25449f66ea76693b51f631fdd190821683c65e65e68d990b36c2d1ae9dd2"
 dependencies = [
+ "humantime",
+ "lazy_static",
+ "log",
  "rand 0.8.6",
- "spin 0.10.1",
+ "spin",
 ]
 
 [[package]]
@@ -6190,7 +6126,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -6637,7 +6573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -493,8 +493,18 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
 dependencies = [
+ "bincode_derive",
  "serde",
  "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -807,7 +817,7 @@ dependencies = [
 [[package]]
 name = "consul-client"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "camino",
  "http",
@@ -860,7 +870,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "corro-api-types"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "camino",
  "compact_str",
@@ -879,7 +889,7 @@ dependencies = [
 [[package]]
 name = "corro-base-types"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "camino",
  "compact_str",
@@ -899,7 +909,7 @@ dependencies = [
 [[package]]
 name = "corro-types"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "antithesis_sdk",
  "arc-swap",
@@ -955,7 +965,7 @@ dependencies = [
 [[package]]
 name = "corro-utils"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "eyre",
  "tokio",
@@ -1783,6 +1793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,6 +1896,29 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.4",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -3269,6 +3308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
 
 [[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3884,7 +3929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3930,6 +3975,21 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xdp",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -4034,6 +4094,7 @@ name = "quilkin-corrosion"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bincode",
  "bytes",
  "camino",
  "compact_str",
@@ -4041,18 +4102,25 @@ dependencies = [
  "corro-types",
  "data-encoding",
  "eyre",
+ "foca",
  "futures",
+ "futures-util",
+ "governor",
  "indexmap",
+ "itertools 0.14.0",
  "parking_lot",
  "prometheus",
  "quilkin-types",
  "quinn",
  "quinn-plaintext",
+ "rand 0.9.4",
+ "rangemap",
  "rusqlite",
  "serde",
  "serde_json",
  "smallvec",
  "spawn",
+ "speedy",
  "sqlite-pool",
  "thiserror 2.0.18",
  "time",
@@ -4349,6 +4417,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -5045,7 +5122,7 @@ dependencies = [
 [[package]]
 name = "spawn"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "futures",
  "parking_lot",
@@ -5093,9 +5170,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "sqlite-functions"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -5104,7 +5190,7 @@ dependencies = [
 [[package]]
 name = "sqlite-pool"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "arc-swap",
  "deadpool",
@@ -5761,7 +5847,7 @@ dependencies = [
 [[package]]
 name = "tripwire"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#4e4cdd7847ffc83f23a4c283623d459dea547e23"
 dependencies = [
  "futures",
  "futures-util",
@@ -5971,6 +6057,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -409,7 +409,7 @@ source = "git+https://github.com/aya-rs/aya?rev=2453204#2453204a9b07a3a92d538f7c
 dependencies = [
  "assert_matches",
  "aya-obj",
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.17.1",
  "libc",
  "log",
@@ -505,6 +505,12 @@ checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -801,7 +807,7 @@ dependencies = [
 [[package]]
 name = "consul-client"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "camino",
  "http",
@@ -854,7 +860,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 [[package]]
 name = "corro-api-types"
 version = "0.2.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "camino",
  "compact_str",
@@ -873,7 +879,7 @@ dependencies = [
 [[package]]
 name = "corro-base-types"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "camino",
  "compact_str",
@@ -893,7 +899,7 @@ dependencies = [
 [[package]]
 name = "corro-types"
 version = "0.1.0-alpha.1"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "antithesis_sdk",
  "arc-swap",
@@ -942,14 +948,14 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tripwire",
- "uhlc",
+ "uhlc 0.7.0",
  "uuid",
 ]
 
 [[package]]
 name = "corro-utils"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "eyre",
  "tokio",
@@ -981,7 +987,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tripwire",
- "uhlc",
+ "uhlc 0.9.0",
  "uuid",
 ]
 
@@ -1105,7 +1111,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crossterm_winapi",
  "document-features",
  "parking_lot",
@@ -1236,6 +1242,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "defmt"
+version = "0.3.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
+dependencies = [
+ "defmt 1.1.1",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2329,7 +2375,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "inotify-sys",
  "libc",
 ]
@@ -2380,7 +2426,7 @@ version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
 ]
@@ -2667,7 +2713,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -3172,7 +3218,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cfg-if",
  "libc",
 ]
@@ -3228,7 +3274,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3246,7 +3292,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -3838,7 +3884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -4015,7 +4061,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tripwire",
- "uhlc",
+ "uhlc 0.9.0",
  "uuid",
 ]
 
@@ -4351,7 +4397,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4504,7 +4550,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "chrono",
  "fallible-iterator",
  "fallible-streaming-iterator",
@@ -4568,7 +4614,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4736,7 +4782,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4999,7 +5045,7 @@ dependencies = [
 [[package]]
 name = "spawn"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "futures",
  "parking_lot",
@@ -5036,6 +5082,12 @@ dependencies = [
 
 [[package]]
 name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+
+[[package]]
+name = "spin"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
@@ -5043,7 +5095,7 @@ checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 [[package]]
 name = "sqlite-functions"
 version = "0.1.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "rusqlite",
  "serde_json",
@@ -5052,7 +5104,7 @@ dependencies = [
 [[package]]
 name = "sqlite-pool"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "arc-swap",
  "deadpool",
@@ -5081,7 +5133,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9add252f9b70a7d493b03127524ed06cdf7480b3dc8c1b2ccfda89384d90a8b7"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "cc",
  "fallible-iterator",
  "indexmap",
@@ -5226,7 +5278,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5559,7 +5611,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -5709,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "tripwire"
 version = "0.1.0-alpha.0"
-source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ba3d3376c774ea6655b13c2b055a2c16b63334e6"
+source = "git+https://github.com/EmbarkStudios/corrosion?branch=misc#ea94fc461b974702b621af9aa06f11317f8008c0"
 dependencies = [
  "futures",
  "futures-util",
@@ -5785,15 +5837,27 @@ checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uhlc"
-version = "0.9.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bb25449f66ea76693b51f631fdd190821683c65e65e68d990b36c2d1ae9dd2"
+checksum = "99b6df3f3e948b40e20c38a6d1fd6d8f91b3573922fc164e068ad3331560487e"
 dependencies = [
+ "defmt 0.3.100",
  "humantime",
  "lazy_static",
  "log",
  "rand 0.8.6",
- "spin",
+ "serde",
+ "spin 0.9.9",
+]
+
+[[package]]
+name = "uhlc"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55bb25449f66ea76693b51f631fdd190821683c65e65e68d990b36c2d1ae9dd2"
+dependencies = [
+ "rand 0.8.6",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -6034,7 +6098,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -6481,7 +6545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/crates/corrosion-tests/src/lib.rs
+++ b/crates/corrosion-tests/src/lib.rs
@@ -12,7 +12,7 @@ pub struct TestSubsDb {
     pub sub_path: camino::Utf8PathBuf,
     pub subs: pubsub::SubsManager,
     pub schema: Arc<types::schema::Schema>,
-    pub clock: Arc<uhlc::HLC>,
+    pub clock: corrosion::Clock,
     pub actor_id: ActorId,
     pub pool: types::agent::SplitPool,
     matcher_conns: std::collections::BTreeMap<uuid::Uuid, types::sqlite::CrConn>,
@@ -41,9 +41,10 @@ impl TestSubsDb {
             db.pool.clone(),
             subs.clone(),
             None,
-        )
-        .await
-        .expect("failed to create broadcaster");
+            db.bookie,
+            db.booked,
+            None,
+        );
 
         Self {
             temp,

--- a/crates/corrosion-tests/tests/disk_full.rs
+++ b/crates/corrosion-tests/tests/disk_full.rs
@@ -327,9 +327,10 @@ async fn end_to_end_recovery_from_real_sqlite_full() {
         db.pool.clone(),
         corro_types::pubsub::SubsManager::default(),
         None,
+        db.bookie,
+        db.booked,
+        None,
     )
-    .await
-    .expect("setup failed")
     .with_full_purge_count(50);
 
     let peer = SocketAddrV6::new(std::net::Ipv6Addr::LOCALHOST, 9001, 0, 0);

--- a/crates/corrosion-tests/tests/disk_full.rs
+++ b/crates/corrosion-tests/tests/disk_full.rs
@@ -358,8 +358,7 @@ async fn end_to_end_recovery_from_real_sqlite_full() {
                 })
             })
             .await;
-
-        if let Err(ChangeError::Rusqlite { ref source, .. }) = result
+        if let Err(ChangeError::Rusqlite { source, .. }) = &result
             && db::is_disk_full(source)
         {
             triggered_full = true;

--- a/crates/corrosion/Cargo.toml
+++ b/crates/corrosion/Cargo.toml
@@ -15,7 +15,7 @@ compact_str.workspace = true
 data-encoding.workspace = true
 eyre.workspace = true
 futures.workspace = true
-indexmap = "2.13"
+futures-util.workspace = true
 parking_lot.workspace = true
 prometheus.workspace = true
 quilkin-types.workspace = true
@@ -34,8 +34,20 @@ tracing.workspace = true
 uhlc.workspace = true
 uuid.workspace = true
 
+# Packages from the corrosion repo, most of which are not published
 corro-api-types.workspace = true
 corro-types.workspace = true
 spawn.workspace = true
 sqlite-pool.workspace = true
 tripwire.workspace = true
+
+# Ensure these versions match the versions from corro-types, they are transitive
+# dependencies that are not re-exported
+bincode = "2.0"
+foca = "0.19"
+governor = { version = "0.10", features = ["std"] }
+indexmap = "2.13"
+itertools = "0.14"
+rand.workspace = true
+rangemap = "1.7"
+speedy = "0.8"

--- a/crates/corrosion/src/db.rs
+++ b/crates/corrosion/src/db.rs
@@ -1,6 +1,6 @@
 use corro_types::{
-    actor::ActorId,
-    agent::{SplitPool, WriteConn},
+    actor::{ActorId, ClusterId},
+    agent::{Booked, Bookie, SplitPool, WriteConn},
     schema::Schema,
     sqlite::{CrConn, SqlitePoolError},
 };
@@ -131,13 +131,22 @@ impl Default for DBMaintenance {
 pub struct InitializedDb {
     /// Pool used to interact with the DB
     pub pool: SplitPool,
+    /// Bookie
+    pub bookie: Bookie,
+    /// All booked versions
+    pub booked: Booked,
     /// The CRSQL clock
-    pub clock: Arc<uhlc::HLC>,
+    pub clock: crate::Clock,
     /// The parsed and verified schema
     pub schema: Arc<Schema>,
     /// The unique actor ID for this database connection, distinguishing it from
     /// other actors that gossip DB changes
     pub actor_id: ActorId,
+    /// The cluster identifier
+    ///
+    /// This essentially determines the "version" of a database so that nodes only gossip changes with other nodes with
+    /// the same cluster id
+    pub cluster_id: ClusterId,
 }
 
 impl InitializedDb {
@@ -170,18 +179,32 @@ impl InitializedDb {
         let write_sema = Arc::new(tokio::sync::Semaphore::new(1));
         let pool = SplitPool::create(&db_path, write_sema.clone(), ONE_GIB).await?;
 
-        let clock = Arc::new(
+        let clock = crate::Clock(Arc::new(
             uhlc::HLCBuilder::default()
                 .with_id(actor_id.try_into().unwrap())
                 .with_max_delta(std::time::Duration::from_millis(300))
                 .build(),
-        );
+        ));
+
+        let cluster_id = {
+            let conn = pool.read().await?;
+
+            match conn.query_row(
+                "SELECT value FROM __corro_state WHERE key = 'cluster_id'",
+                [],
+                |row| row.get(0),
+            ) {
+                Ok(value) => value,
+                Err(rusqlite::Error::QueryReturnedNoRows) => Default::default(),
+                Err(e) => return Err(e.into()),
+            }
+        };
 
         let schema = {
             let mut conn = pool.write_priority().await?;
 
             let old_schema = {
-                corro_types::agent::migrate(clock.clone(), &mut conn)?;
+                corro_types::agent::migrate(clock.0.clone(), &mut conn)?;
                 let mut schema = corro_types::schema::init_schema(&conn)?;
                 schema.constrain()?;
 
@@ -202,11 +225,33 @@ impl InitializedDb {
             spawn_db_maintenance(db_path, pool.clone(), dbm);
         }
 
+        use eyre::WrapErr;
+        let start = std::time::Instant::now();
+        let conn = pool
+            .read_readonly()
+            .await
+            .context("failed to acquire read")?;
+
+        let (bookie, booked) =
+            tokio::task::block_in_place(|| -> eyre::Result<(Bookie, Booked)> {
+                let all_booked = corro_types::agent::BookedVersions::load_all_from_conn(&conn)
+                    .context("failed to load booked versions")?;
+
+                let bookie = Bookie::new(all_booked);
+                let booked = bookie.ensure(actor_id);
+                Ok((bookie, booked))
+            })?;
+
+        tracing::info!(elapsed = ?start.elapsed(), "Loaded booked versions");
+
         Ok(Self {
             pool,
+            bookie,
+            booked,
             clock,
             schema: Arc::new(schema),
             actor_id,
+            cluster_id,
         })
     }
 }

--- a/crates/corrosion/src/db.rs
+++ b/crates/corrosion/src/db.rs
@@ -186,20 +186,6 @@ impl InitializedDb {
                 .build(),
         ));
 
-        let cluster_id = {
-            let conn = pool.read().await?;
-
-            match conn.query_row(
-                "SELECT value FROM __corro_state WHERE key = 'cluster_id'",
-                [],
-                |row| row.get(0),
-            ) {
-                Ok(value) => value,
-                Err(rusqlite::Error::QueryReturnedNoRows) => Default::default(),
-                Err(e) => return Err(e.into()),
-            }
-        };
-
         let schema = {
             let mut conn = pool.write_priority().await?;
 
@@ -219,6 +205,20 @@ impl InitializedDb {
             tokio::task::block_in_place(|| run_startup_checks(&conn, limits))?;
 
             schema
+        };
+
+        let cluster_id = {
+            let conn = pool.read().await?;
+
+            match conn.query_row(
+                "SELECT value FROM __corro_state WHERE key = 'cluster_id'",
+                [],
+                |row| row.get(0),
+            ) {
+                Ok(value) => value,
+                Err(rusqlite::Error::QueryReturnedNoRows) => Default::default(),
+                Err(e) => return Err(e.into()),
+            }
         };
 
         if let Some(dbm) = maintenance {

--- a/crates/corrosion/src/gossip.rs
+++ b/crates/corrosion/src/gossip.rs
@@ -6,7 +6,7 @@ pub mod sync;
 pub mod transport;
 
 use corro_types::broadcast as bx;
-use metrics::GossipMetrics;
+pub use metrics::GossipMetrics;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
@@ -122,3 +122,6 @@ fn fatal_db_issue(issue: &'static str, stx: &tokio::sync::watch::Sender<()>) {
     tracing::error!(issue, "fatal DB issue encountered, attempting shutdown");
     let _dont_care = stx.send(());
 }
+
+#[derive(Clone)]
+pub struct Members(pub std::sync::Arc<parking_lot::RwLock<corro_types::members::Members>>);

--- a/crates/corrosion/src/gossip.rs
+++ b/crates/corrosion/src/gossip.rs
@@ -1,0 +1,122 @@
+pub mod changes;
+pub mod handler;
+pub mod metrics;
+pub mod swim;
+pub mod sync;
+pub mod transport;
+
+use corro_types::broadcast as bx;
+use metrics::GossipMetrics;
+use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
+
+pub type ChangeAndSource = (bx::ChangeV1, bx::ChangeSource);
+
+pub enum Change {
+    Bulk(Vec<ChangeAndSource>),
+    Single(ChangeAndSource),
+}
+
+impl Change {
+    fn len(&self) -> usize {
+        match self {
+            Self::Bulk(b) => b.len(),
+            Self::Single(_) => 1,
+        }
+    }
+}
+
+pub enum ChangeIter {
+    Bulk(std::iter::Rev<std::vec::IntoIter<ChangeAndSource>>),
+    Single(std::iter::Once<ChangeAndSource>),
+}
+
+impl Iterator for ChangeIter {
+    type Item = ChangeAndSource;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Bulk(v) => v.next(),
+            Self::Single(s) => s.next(),
+        }
+    }
+}
+
+impl IntoIterator for Change {
+    type Item = ChangeAndSource;
+    type IntoIter = ChangeIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::Bulk(v) => ChangeIter::Bulk(v.into_iter().rev()),
+            Self::Single(change) => ChangeIter::Single(std::iter::once(change)),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct GossipContext {
+    pub metrics: &'static GossipMetrics,
+    pub foca_tx: Sender<bx::FocaInput>,
+    pub changes_tx: Sender<Change>,
+    pub bookie: corro_types::bookie::Bookie,
+    pub cluster_id: corro_types::actor::ClusterId,
+    pub actor_id: corro_types::actor::ActorId,
+    pub clock: crate::Clock,
+    pub sync_permits: Arc<tokio::sync::Semaphore>,
+    pub pool: corro_types::agent::SplitPool,
+}
+
+struct StreamMetrics {
+    m: &'static GossipMetrics,
+    dir: quinn::Dir,
+}
+
+impl StreamMetrics {
+    #[inline]
+    fn uni(m: &'static GossipMetrics) -> Self {
+        tracing::trace!("accepted unidirectional gossip stream");
+        m.streams_inc(quinn::Dir::Uni);
+
+        Self {
+            m,
+            dir: quinn::Dir::Uni,
+        }
+    }
+
+    #[inline]
+    fn bi(m: &'static GossipMetrics) -> Self {
+        tracing::trace!("accepted bidirectional gossip stream");
+        m.streams_inc(quinn::Dir::Bi);
+
+        Self {
+            m,
+            dir: quinn::Dir::Bi,
+        }
+    }
+
+    #[inline]
+    fn incoming(&self, bytes: &bytes::BytesMut) {
+        self.m
+            .stream_bytes_inc(bytes.len() as _, self.dir, metrics::Direction::In);
+    }
+
+    #[inline]
+    fn outgoing(&self, chunk_len: u64) {
+        self.m
+            .stream_bytes_inc(chunk_len, self.dir, metrics::Direction::Out);
+    }
+}
+
+impl Drop for StreamMetrics {
+    #[inline]
+    fn drop(&mut self) {
+        self.m.streams_dec(self.dir);
+    }
+}
+
+#[inline]
+fn fatal_db_issue(issue: &'static str, stx: &tokio::sync::watch::Sender<()>) {
+    tracing::error!(issue, "fatal DB issue encountered, attempting shutdown");
+    let _dont_care = stx.send(());
+}

--- a/crates/corrosion/src/gossip.rs
+++ b/crates/corrosion/src/gossip.rs
@@ -10,6 +10,8 @@ use metrics::GossipMetrics;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
+use crate::gossip::transport::TrafficClass;
+
 pub type ChangeAndSource = (bx::ChangeV1, bx::ChangeSource);
 
 pub enum Change {
@@ -76,7 +78,7 @@ impl StreamMetrics {
     #[inline]
     fn uni(m: &'static GossipMetrics) -> Self {
         tracing::trace!("accepted unidirectional gossip stream");
-        m.streams_inc(quinn::Dir::Uni);
+        m.server_streams_inc(quinn::Dir::Uni);
 
         Self {
             m,
@@ -87,7 +89,7 @@ impl StreamMetrics {
     #[inline]
     fn bi(m: &'static GossipMetrics) -> Self {
         tracing::trace!("accepted bidirectional gossip stream");
-        m.streams_inc(quinn::Dir::Bi);
+        m.server_streams_inc(quinn::Dir::Bi);
 
         Self {
             m,
@@ -96,22 +98,22 @@ impl StreamMetrics {
     }
 
     #[inline]
-    fn incoming(&self, bytes: &bytes::BytesMut) {
+    fn incoming(&self, bytes: &bytes::BytesMut, traffic: TrafficClass) {
         self.m
-            .stream_bytes_inc(bytes.len() as _, self.dir, metrics::Direction::In);
+            .stream_bytes_inc(bytes.len() as _, self.dir, metrics::Direction::In, traffic);
     }
 
     #[inline]
-    fn outgoing(&self, chunk_len: u64) {
+    fn outgoing(&self, chunk_len: u64, traffic: TrafficClass) {
         self.m
-            .stream_bytes_inc(chunk_len, self.dir, metrics::Direction::Out);
+            .stream_bytes_inc(chunk_len, self.dir, metrics::Direction::Out, traffic);
     }
 }
 
 impl Drop for StreamMetrics {
     #[inline]
     fn drop(&mut self) {
-        self.m.streams_dec(self.dir);
+        self.m.server_streams_dec(self.dir);
     }
 }
 

--- a/crates/corrosion/src/gossip/changes.rs
+++ b/crates/corrosion/src/gossip/changes.rs
@@ -1,0 +1,1026 @@
+use super::{ChangeAndSource, GossipMetrics};
+use crate::Clock;
+use corro_types::{
+    actor::ActorId,
+    agent::{self, ChangeError, CurrentVersion, KnownDbVersion, PartialVersion},
+    base::{CrsqlDbVersion, CrsqlDbVersionRange, CrsqlSeq},
+    bookie::{Booked, Bookie},
+    broadcast::{self as bx, ChangeV1, Changeset, ChangesetParts},
+    sqlite::unnest_param,
+};
+use rangemap::RangeInclusiveSet;
+use std::{
+    collections::{BTreeMap, HashSet, VecDeque},
+    time::{Duration, Instant},
+};
+use tokio::sync::mpsc;
+
+/// State for dynamic batch processing
+struct HandleChangesState {
+    queue: VecDeque<(ChangeAndSource, Instant)>,
+    buf_cost: usize,
+    current_batch_size: usize,
+    processing_task: Option<tokio::task::JoinHandle<Result<(), ChangeError>>>,
+    max_wait: Option<std::pin::Pin<Box<tokio::time::Sleep>>>,
+
+    /// When emergency halving last occurred; prevents batch size re-inflation
+    /// during the grace period to avoid oscillation (halve → burst → halve …)
+    halved_at: Option<Instant>,
+
+    // Configuration
+    max_queue_len: usize,
+    min_batch_size: usize,
+    step_base: usize,
+    max_batch_size: usize,
+    batch_threshold_ratio: f64,
+    timeout_duration: Duration,
+
+    /// Duration after emergency halving during which batch size increases are blocked.
+    ///
+    /// Uses the transaction timeout as a reasonable proxy for "one full processing cycle".
+    tx_timeout: Duration,
+
+    metrics: &'static GossipMetrics,
+}
+
+impl HandleChangesState {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        min_batch_size: usize,
+        step_base: usize,
+        max_batch_size: usize,
+        batch_threshold_ratio: f64,
+        timeout_duration: Duration,
+        tx_timeout: Duration,
+        max_queue_len: usize,
+        metrics: &'static GossipMetrics,
+    ) -> Self {
+        Self {
+            queue: VecDeque::with_capacity(max_queue_len),
+            buf_cost: 0,
+            current_batch_size: min_batch_size,
+            processing_task: None,
+            max_wait: Some(Box::pin(tokio::time::sleep(timeout_duration))),
+            halved_at: None,
+            min_batch_size,
+            step_base,
+            max_batch_size,
+            batch_threshold_ratio,
+            timeout_duration,
+            tx_timeout,
+            max_queue_len,
+            metrics,
+        }
+    }
+
+    /// Whether we're still in the grace period after an emergency halving.
+    #[inline]
+    fn in_grace_period(&self) -> bool {
+        self.halved_at
+            .is_some_and(|t| t.elapsed() < self.tx_timeout)
+    }
+
+    /// Calculate exponential batch size based on cost.
+    ///
+    /// During the grace period after emergency halving, the result is clamped
+    /// to `current_batch_size` to prevent re-inflation and oscillation.
+    #[inline]
+    fn calculate_batch_size(&self, cost: usize) -> usize {
+        let computed = if self.step_base == 0 || cost < self.step_base {
+            self.min_batch_size
+        } else {
+            let size = self.step_base * (1 << (cost / self.step_base).ilog2());
+            size.clamp(self.min_batch_size, self.max_batch_size)
+        };
+        if self.in_grace_period() {
+            computed.min(self.current_batch_size)
+        } else {
+            computed
+        }
+    }
+
+    /// Get the threshold for immediate spawning based on configured ratio
+    #[inline]
+    fn batch_threshold(&self) -> usize {
+        (self.current_batch_size as f64 * self.batch_threshold_ratio) as usize
+    }
+
+    /// Drain a batch from the queue and spawn processing task
+    fn drain_and_spawn(
+        &mut self,
+        ctx: &ChangeCtx,
+        target_size: usize,
+        reason: &'static str,
+    ) -> usize {
+        // Must complete previous task before spawning a new one
+        if self.processing_task.is_some() {
+            unreachable!("a processing task already exists");
+        }
+
+        let mut batch = Vec::with_capacity(self.current_batch_size);
+        let mut batch_cost = 0;
+
+        while let Some((change, queued_at)) = self.queue.pop_front() {
+            let cost = change.0.processing_cost();
+            batch_cost += cost;
+            self.buf_cost -= cost;
+            batch.push((change, queued_at));
+
+            if batch_cost >= target_size {
+                break;
+            }
+        }
+
+        if batch.is_empty() {
+            unreachable!("batch is empty");
+        }
+
+        let ctx = ctx.clone();
+        self.processing_task = Some(tokio::spawn(process_multiple_changes(
+            ctx,
+            batch,
+            self.tx_timeout,
+        )));
+
+        self.metrics.change_batches_inc(reason);
+        self.metrics.change_batch_size(self.current_batch_size);
+
+        batch_cost
+    }
+
+    /// Handle task completion and decide whether to spawn next batch
+    fn handle_task_completion(
+        &mut self,
+        ctx: &ChangeCtx,
+        result: Result<Result<(), corro_types::agent::ChangeError>, tokio::task::JoinError>,
+    ) {
+        // Handle task result
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                tracing::error!(%error, "error processing change batch");
+
+                if let Some(issue) = error.fatal_db_issue() {
+                    super::fatal_db_issue(issue, &ctx.shutdown);
+                }
+
+                // Check for memory errors and emergency reduce batch size
+                // TODO: requeue the changes
+                if error.is_oom_error() || error.is_interrupt_error() {
+                    if self.current_batch_size == self.min_batch_size {
+                        tracing::error!(current_batch_size = %self.current_batch_size, min_batch_size = %self.min_batch_size, "batch too large for the database to process, but already at min_batch_size — min_batch_size may be too large or transaction timeout may be misconfigured");
+                    } else {
+                        tracing::error!(current_batch_size = %self.current_batch_size, "batch too large for the database to process, halving batch size");
+                    }
+                    self.current_batch_size =
+                        (self.current_batch_size / 2).max(self.min_batch_size);
+                    self.halved_at = Some(std::time::Instant::now());
+                }
+            }
+            Err(error) => {
+                tracing::error!(%error, "batch processing task panicked");
+            }
+        }
+
+        self.processing_task = None;
+
+        // Should we spawn immediately with queued changes?
+        if self.buf_cost >= self.batch_threshold() {
+            // YES - enough changes queued, spawn immediately
+            // Check if we might want to burst
+            if self.buf_cost > self.current_batch_size {
+                self.current_batch_size = self.calculate_batch_size(self.buf_cost);
+            }
+            self.drain_and_spawn(ctx, self.current_batch_size, "immediate-after-completion");
+        } else {
+            // NO - not enough changes yet, start timeout
+            self.max_wait = Some(Box::pin(tokio::time::sleep(self.timeout_duration)));
+        }
+    }
+
+    /// Handle timeout - spawn whatever we have
+    ///
+    /// The amount of changes MUST be smaller than the threshold
+    /// as otherwise other code paths would have spawned a batch
+    fn handle_timeout(&mut self, ctx: &ChangeCtx) {
+        self.metrics.changes_queued(self.buf_cost, self.queue.len());
+
+        self.max_wait = None;
+
+        if !self.queue.is_empty() {
+            // Just process whatever we have and then downsize the batch size
+            self.drain_and_spawn(ctx, usize::MAX, "timeout");
+
+            // Adjust batch size based on what we had processed
+            // This will decrease the batch size unless it's already at the minimum
+            self.current_batch_size = self.calculate_batch_size(self.buf_cost);
+        } else if self.processing_task.is_none() && self.max_wait.is_none() {
+            // Empty queue, no task running, no timeout set
+            self.current_batch_size = self.calculate_batch_size(0);
+            // If no task is running and no timeout is set, start timeout
+            // This ensures changes get processed even if they don't hit the threshold
+            self.max_wait = Some(Box::pin(tokio::time::sleep(self.timeout_duration)));
+        }
+    }
+
+    // Drops oldest items when the queue is full
+    #[inline]
+    fn maybe_drop_old_change(&mut self) -> Option<ChangeV1> {
+        let maybe_dropped_change = if self.queue.len() >= self.max_queue_len {
+            if let Some((dropped_change, _)) = self.queue.pop_front() {
+                self.buf_cost -= dropped_change.0.processing_cost();
+                Some(dropped_change.0)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if maybe_dropped_change.is_some() {
+            self.metrics.change_dropped_inc();
+        }
+
+        maybe_dropped_change
+    }
+
+    /// Handle new change arrival - check if we should spawn immediately
+    fn handle_new_change(&mut self, ctx: &ChangeCtx, change: ChangeAndSource) {
+        let cost = change.0.processing_cost();
+        self.queue.push_back((change, Instant::now()));
+        self.buf_cost += cost;
+
+        // Check if we should spawn immediately (threshold-based)
+        if self.buf_cost < self.batch_threshold() || self.processing_task.is_some() {
+            return;
+        }
+
+        // Cancel any pending timeout
+        self.max_wait = None;
+
+        // Check if we might want to burst
+        if self.buf_cost > self.current_batch_size {
+            self.current_batch_size = self.calculate_batch_size(self.buf_cost);
+        }
+
+        // Drain and spawn
+        self.drain_and_spawn(ctx, self.current_batch_size, "size-threshold-on-new-change");
+    }
+}
+
+pub struct ChangeOptions {
+    /// How many unapplied changesets corrosion will buffer before starting to drop them
+    pub processing_queue_len: usize,
+    /// Minimum amount of changes corrosion will try to apply at once in the same transaction
+    pub apply_queue_min_batch_size: usize,
+    /// `batch_size = clamp(min_batch_size, step_base * 2 ** floor(log2(x/step_base)), max_batch_size)`
+    pub apply_queue_step_base: usize,
+    /// Maximum amount of changes corrosion will try to apply at once in the same transaction
+    pub apply_queue_max_batch_size: usize,
+    /// Threshold ratio (0.0-1.0) for immediate batch spawning when queue reaches this fraction of batch size
+    ///
+    /// It's used to decide whether to wait for more changes for `apply_queue_timeout` ms or spawn a batch immediately
+    pub apply_queue_batch_threshold_ratio: f64,
+    /// Amount of time corrosion will wait before proceeding to apply a batch of changes
+    ///
+    /// We wait either for `apply_queue_timeout` or until at least `apply_queue_min_batch_size` changes accumulate
+    pub apply_queue_timeout: Duration,
+    /// Max amount of a time allowed for an individual SQL transaction
+    pub sql_tx_timeout: Duration,
+}
+
+impl Default for ChangeOptions {
+    fn default() -> Self {
+        Self {
+            processing_queue_len: 20_000,
+            apply_queue_min_batch_size: 100,
+            apply_queue_step_base: 500,
+            apply_queue_max_batch_size: 16_000,
+            apply_queue_batch_threshold_ratio: 0.9,
+            apply_queue_timeout: Duration::from_millis(10),
+            sql_tx_timeout: Duration::from_secs(60),
+        }
+    }
+}
+
+pub enum ClearVersionRange {
+    Single(CrsqlDbVersionRange),
+    Set(RangeInclusiveSet<CrsqlDbVersion>),
+}
+
+#[derive(Clone)]
+pub struct ChangeCtx {
+    pub pool: agent::SplitPool,
+    pub sub_manager: corro_types::pubsub::SubsManager,
+    pub update_manager: corro_types::updates::UpdatesManager,
+    pub bookie: Bookie,
+    pub actor_id: ActorId,
+    pub clock: Clock,
+    pub bcast_tx: mpsc::Sender<bx::BroadcastInput>,
+    pub apply_tx: mpsc::Sender<(ActorId, Vec<CrsqlDbVersion>)>,
+    pub clear_buf_tx: mpsc::Sender<(ActorId, ClearVersionRange)>,
+    pub shutdown: tokio::sync::watch::Sender<()>,
+    pub metrics: &'static super::GossipMetrics,
+}
+
+/// Bundle incoming changes to optimise transaction sizes with `SQLite`
+///
+/// *Performance tradeoff*: introduce latency (with a max timeout) to
+/// apply changes more efficiently.
+///
+/// This function used by broadcast receivers and sync receivers
+pub async fn handle_changes(
+    ctx: ChangeCtx,
+    opts: ChangeOptions,
+    mut rx_changes: mpsc::Receiver<super::Change>,
+    mut tripwire: tripwire::Tripwire,
+) {
+    // Initialize batch processor state
+    let mut state = HandleChangesState::new(
+        opts.apply_queue_min_batch_size,
+        opts.apply_queue_step_base,
+        opts.apply_queue_max_batch_size,
+        opts.apply_queue_batch_threshold_ratio,
+        opts.apply_queue_timeout,
+        opts.sql_tx_timeout,
+        opts.processing_queue_len,
+        ctx.metrics,
+    );
+
+    let max_seen_cache_len = opts.processing_queue_len;
+
+    // unlikely, but max_seen_cache_len can be less than 10, in that case we want to just clear the whole cache
+    let keep_seen_cache_size = if max_seen_cache_len > 10 {
+        10.max(max_seen_cache_len / 10)
+    } else {
+        0
+    };
+
+    let mut seen = indexmap::IndexMap::<_, RangeInclusiveSet<CrsqlSeq>>::new();
+
+    loop {
+        let changes = tokio::select! {
+            biased;
+
+            // Processing task finished
+            res = async { state.processing_task.as_mut().unwrap().await }, if state.processing_task.is_some() => {
+                state.handle_task_completion(&ctx, res);
+                continue;
+            },
+
+            // New changes arrive
+            maybe_change_src = rx_changes.recv() => match maybe_change_src {
+                Some(change) => change,
+                None => break,
+            },
+
+            // Timeout fires
+            _ = async { state.max_wait.as_mut().unwrap().await }, if state.max_wait.is_some() => {
+                state.handle_timeout(&ctx);
+
+                // Cleanup seen cache
+                if seen.len() > max_seen_cache_len {
+                    seen.drain(..seen.len() - keep_seen_cache_size);
+                }
+
+                continue;
+            },
+
+            // Corrosion is shutting down
+            _ = &mut tripwire => {
+                break;
+            }
+        };
+
+        ctx.metrics.change_received_inc(changes.len());
+
+        for (change, src) in changes {
+            // Skip changes from ourselves
+            // TODO: seems better to just ensure we don't send to ourselves?
+            if change.actor_id == ctx.actor_id {
+                continue;
+            }
+
+            // Skip changes we've already seen recently in the seen cache
+            if let Some(mut seqs) = change.seqs() {
+                let v = change.versions().start();
+                if let Some(seen_seqs) = seen.get(&(change.actor_id, v))
+                    && seqs.all(|seq| seen_seqs.contains(&seq))
+                {
+                    continue;
+                }
+            } else if change
+                .versions()
+                .all(|v| seen.contains_key(&(change.actor_id, v)))
+            {
+                if src.is_broadcast() {
+                    ctx.metrics.change_broadcast_duplicate_inc("cache");
+                }
+                continue;
+            }
+
+            let src_str = src.as_str();
+
+            // Update logical clock if needed
+            let recv_lag = change.ts().and_then(|ts| {
+                let mut our_ts = ctx.clock.new_timestamp();
+                if ts > our_ts {
+                    if let Err(error) = ctx.clock.update_with_timestamp(change.actor_id, ts) {
+                        tracing::error!(remote_actor_id = %change.actor_id, error, "could not update clock from actor");
+                        return None;
+                    }
+
+                    ctx.metrics.change_clock_inc(src_str);
+
+                    // update our_ts to the new timestamp
+                    our_ts = ctx.clock.new_timestamp();
+                }
+                Some((our_ts.0 - ts.0).to_duration())
+            });
+
+            if src.is_broadcast() {
+                ctx.metrics.change_broadcast_received_inc("change");
+            }
+
+            // Skip changes we've already seen in the bookie
+            if let Some(booked) = ctx.bookie.get(&change.actor_id)
+                && booked.read().contains_all(change.versions(), change.seqs())
+            {
+                if src.is_broadcast() {
+                    ctx.metrics.change_broadcast_duplicate_inc("bookie");
+                }
+                continue;
+            }
+
+            if let Some(recv_lag) = recv_lag {
+                ctx.metrics
+                    .change_recv_lag_sample(recv_lag.as_secs_f64(), src_str);
+            }
+
+            // If we need to drop an old change, drop it from the seen cache as well
+            while let Some(dropped_change) = state.maybe_drop_old_change() {
+                for v in dropped_change.versions() {
+                    let indexmap::map::Entry::Occupied(mut entry) =
+                        seen.entry((change.actor_id, v))
+                    else {
+                        continue;
+                    };
+
+                    if let Some(seqs) = dropped_change.seqs() {
+                        entry.get_mut().remove(seqs.into());
+                    } else {
+                        entry.swap_remove_entry();
+                    }
+                }
+            }
+
+            // Register the new change in the seen cache
+            // this will only run once for a non-empty changeset
+            for v in change.versions() {
+                let entry = seen.entry((change.actor_id, v)).or_default();
+                if let Some(seqs) = change.seqs() {
+                    entry.extend([seqs.into()]);
+                }
+            }
+
+            // Rebroadcast changes received from broadcast
+            if src.is_broadcast()
+                && !change.is_empty()
+                && ctx
+                    .bcast_tx
+                    .try_send(bx::BroadcastInput::Rebroadcast(bx::BroadcastV1::Change(
+                        change.clone(),
+                    )))
+                    .is_err()
+            {
+                tracing::debug!("broadcasts are full or done!");
+            }
+
+            // Handle the new change - queue it and potentially spawn a batch
+            state.handle_new_change(&ctx, (change, src));
+        }
+    }
+}
+
+async fn process_multiple_changes(
+    ctx: ChangeCtx,
+    changes: Vec<(ChangeAndSource, Instant)>,
+    tx_timeout: Duration,
+) -> Result<(), corro_types::agent::ChangeError> {
+    let start = Instant::now();
+    //counter!("corro.agent.changes.processing.started").increment(changes.len() as u64);
+
+    const PROCESSING_WARN_THRESHOLD: Duration = Duration::from_secs(5);
+
+    let mut seen = HashSet::new();
+    let mut unknown_changes = BTreeMap::<ActorId, (Booked, Vec<_>)>::new();
+
+    for ((change, src), queued_at) in changes {
+        ctx.metrics.changes_queued_time(queued_at.elapsed());
+
+        let versions = change.versions();
+        let seqs = change.seqs();
+
+        if !seen.insert((change.actor_id, versions, seqs)) {
+            continue;
+        }
+
+        let booked = ctx.bookie.ensure(change.actor_id);
+        if booked.read().contains_all(change.versions(), change.seqs()) {
+            continue;
+        }
+
+        unknown_changes
+            .entry(change.actor_id)
+            .and_modify(|(_, per_actor_changes)| per_actor_changes.push((change.clone(), src)))
+            .or_insert_with(|| (booked, vec![(change, src)]));
+    }
+
+    let elapsed = start.elapsed();
+    if elapsed >= PROCESSING_WARN_THRESHOLD {
+        tracing::warn!(
+            ?elapsed,
+            "process_multiple_changes: removing duplicates took too long"
+        );
+    }
+
+    if unknown_changes.is_empty() {
+        return Ok(());
+    }
+
+    let mut conn = ctx.pool.write_normal().await?;
+    let ctx = ctx.clone();
+
+    let changesets = tokio::task::block_in_place(move || {
+        let bookie_write = ctx.bookie.write_lock_blocking();
+
+        let tx = conn
+            .immediate_transaction()
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: None,
+                version: None,
+            })?;
+
+        let mut tx = sqlite_pool::InterruptibleTransaction::new(
+            tx,
+            Some(tx_timeout),
+            "process_multiple_changes",
+        );
+
+        let mut processed = BTreeMap::<ActorId, Vec<_>>::new();
+        let mut changesets = Vec::new();
+        let mut booked_writes = BTreeMap::new();
+
+        for (actor_id, (booked, _)) in &unknown_changes {
+            booked_writes.insert(*actor_id, bookie_write.write_tx(booked));
+        }
+
+        let sub_start = Instant::now();
+        for (actor_id, (_, changes)) in unknown_changes {
+            let booked_write = booked_writes
+                .get_mut(&actor_id)
+                .expect("booked write guard should be present for every actor");
+
+            let max = booked_write.last();
+            let mut seen = rangemap::RangeInclusiveMap::new();
+
+            for (change, src) in changes {
+                let seqs = change.seqs();
+                if booked_write.contains_all(change.versions(), change.seqs()) {
+                    continue;
+                }
+
+                let versions = change.versions();
+
+                // check if we've seen this version here...
+                if versions.clone().all(|version| match seqs {
+                    Some(mut check_seqs) => match seen.get(&version) {
+                        Some(maybe_partial) => match maybe_partial {
+                            Some(agent::PartialVersion { seqs, .. }) => {
+                                check_seqs.all(|seq| seqs.contains(&seq))
+                            }
+                            // other kind of known version
+                            None => true,
+                        },
+                        None => false,
+                    },
+                    None => seen.contains_key(&version),
+                }) {
+                    continue;
+                }
+
+                // optimizing this, insert later!
+                let known = if change.is_complete() && change.is_empty() {
+                    let end = change.versions().end();
+
+                    // update db_version in db if it's greater than the max
+                    // since we aren't passing any changes to crsql
+                    if max.is_none_or(|max| end > max) {
+                        drop(
+                            tx.prepare_cached("SELECT crsql_set_db_version(?, ?)")
+                                .map_err(|source| ChangeError::Rusqlite {
+                                    source,
+                                    actor_id: Some(change.actor_id),
+                                    version: Some(end),
+                                })?
+                                .query_row((change.actor_id, end), |row| row.get::<_, String>(0))
+                                .map_err(|source| ChangeError::Rusqlite {
+                                    source,
+                                    actor_id: Some(change.actor_id),
+                                    version: Some(end),
+                                })?,
+                        );
+                    }
+
+                    KnownDbVersion::Cleared
+                } else {
+                    if let Some(seqs) = change.seqs()
+                        && seqs.end() < seqs.start()
+                    {
+                        tracing::warn!(%actor_id, versions = ?change.versions(), "received an invalid change, seqs start is greater than seqs end: {seqs:?}");
+                        continue;
+                    }
+
+                    let (known, changeset) = {
+                        match process_single_version(&ctx.clock, ctx.metrics, &mut tx, change) {
+                            Ok(res) => res,
+                            Err(error) => {
+                                tracing::error!(%actor_id, versions = ?versions, %error, "error processing single version");
+
+                                if let Some(issue) = error
+                                    .sqlite_error_code()
+                                    .and_then(ChangeError::fatal_db_issue_for_code)
+                                {
+                                    super::fatal_db_issue(issue, &ctx.shutdown);
+                                }
+
+                                // the transaction was rolled back, so we need to return.
+                                if tx.is_autocommit() {
+                                    return Err(ChangeError::Rusqlite {
+                                        source: error,
+                                        actor_id: None,
+                                        version: None,
+                                    });
+                                } else {
+                                    continue;
+                                }
+                            }
+                        }
+                    };
+
+                    if let KnownDbVersion::Current(CurrentVersion { db_version, .. }) = &known {
+                        changesets.push((actor_id, changeset, *db_version, src));
+                    }
+
+                    known
+                };
+
+                let partial = match known {
+                    KnownDbVersion::Partial(partial) => Some(partial),
+                    _ => None,
+                };
+
+                seen.insert(versions.into(), partial.clone());
+                processed
+                    .entry(actor_id)
+                    .or_default()
+                    .push((versions, partial));
+            }
+        }
+
+        let elapsed = sub_start.elapsed();
+        if elapsed >= PROCESSING_WARN_THRESHOLD {
+            tracing::warn!(
+                ?elapsed,
+                "process_multiple_changes:: process_single_version took too long"
+            );
+        }
+
+        let sub_start = Instant::now();
+
+        let mut all_changes = Vec::with_capacity(processed.len());
+        let mut completed_versions = BTreeMap::new();
+        for (actor_id, processed) in processed.iter() {
+            let booked_write = booked_writes
+                .get_mut(actor_id)
+                .expect("booked write guard should be present for every actor");
+
+            let (changes, completed_partials) = booked_write.compute_and_apply(processed);
+            let clear_versions = changes
+                .clear_versions
+                .iter()
+                .map(|v| *v..=*v)
+                .collect::<RangeInclusiveSet<CrsqlDbVersion>>();
+            completed_versions.insert(*actor_id, (completed_partials, clear_versions));
+            all_changes.push(changes);
+        }
+
+        corro_types::bookie::BookieDbParams::from_changes(&all_changes)
+            .execute(&tx)
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: None,
+                version: None,
+            })?;
+
+        tx.commit().map_err(|source| {
+            if let Some(issue) = source
+                .sqlite_error_code()
+                .and_then(ChangeError::fatal_db_issue_for_code)
+            {
+                super::fatal_db_issue(issue, &ctx.shutdown);
+            }
+
+            ChangeError::Rusqlite {
+                source,
+                actor_id: None,
+                version: None,
+            }
+        })?;
+
+        let elapsed = sub_start.elapsed();
+        if elapsed >= PROCESSING_WARN_THRESHOLD {
+            tracing::warn!(
+                ?elapsed,
+                "process_multiple_changes: commiting transaction took too long"
+            );
+        }
+
+        for (_, booked_write) in booked_writes {
+            booked_write.commit();
+        }
+
+        // for (_, changeset, _, _) in changesets.iter() {
+        //     if let Some(ts) = changeset.ts() {
+        //         let dur = (agent.clock().new_timestamp().get_time() - ts.0).to_duration();
+        //         histogram!("corro.agent.changes.commit.lag.seconds").record(dur);
+        //         agent.metrics_tracker().observe_lag(dur.as_secs_f64());
+        //     }
+        // }
+
+        // schedule apply for partials that became complete
+        for (actor_id, (versions, clear_versions)) in completed_versions {
+            // try to send synchronously since we're in a blocking task and spawning a task to send a message is kind of gross
+            match ctx.apply_tx.try_reserve() {
+                Ok(permit) => permit.send((actor_id, versions)),
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    let tx = ctx.apply_tx.clone();
+                    tokio::task::spawn(async move {
+                        if tx.send((actor_id, versions)).await.is_err() {
+                            tracing::error!(
+                                "unable to apply further changes, receiver was closed after task spawn"
+                            );
+                        }
+                    });
+                }
+                Err(_) => {
+                    tracing::error!("unable to apply further changes, receiver was closed");
+                }
+            }
+
+            // the corrosion code doesn't seem to think this one isn't critical, or that it won't usually ever be full?
+            if ctx
+                .clear_buf_tx
+                .try_send((actor_id, ClearVersionRange::Set(clear_versions)))
+                .is_err()
+            {
+                tracing::warn!("could not schedule buffered meta clear");
+            }
+        }
+
+        Ok::<_, ChangeError>(changesets)
+    })?;
+
+    let change_chunk_size: usize = changesets.iter().map(|cs| cs.1.len()).sum();
+
+    ctx.metrics
+        .changes_processed(start.elapsed(), "remote", Some(change_chunk_size));
+
+    tokio::spawn(async move {
+        for (_actor_id, changeset, db_version, _src) in changesets {
+            corro_types::updates::match_changes(&ctx.sub_manager, &changeset, db_version);
+            corro_types::updates::match_changes(&ctx.update_manager, &changeset, db_version);
+        }
+    });
+
+    Ok(())
+}
+
+fn process_single_version(
+    clock: &Clock,
+    metrics: &'static GossipMetrics,
+    tx: &mut sqlite_pool::InterruptibleTransaction<rusqlite::Transaction<'_>>,
+    change: ChangeV1,
+) -> rusqlite::Result<(KnownDbVersion, bx::Changeset)> {
+    let ChangeV1 {
+        actor_id,
+        changeset,
+    } = change;
+
+    let versions = changeset.versions();
+
+    let sp = tx.savepoint()?;
+    let mut changes_per_table = BTreeMap::new();
+    let (known, changeset) = if changeset.is_complete() {
+        let (known, changeset) = process_complete_version(
+            clock,
+            &sp,
+            actor_id,
+            versions,
+            changeset
+                .into_parts()
+                .expect("no changeset parts, this shouldn't be happening!"),
+            &mut changes_per_table,
+        )?;
+
+        (known, changeset)
+    } else {
+        let parts = changeset.into_parts().unwrap();
+        let known = process_incomplete_version(&sp, &parts, &mut changes_per_table)?;
+
+        (known, parts.into())
+    };
+
+    sp.commit()?;
+
+    for (table_name, count) in changes_per_table {
+        metrics.changes_committed_inc(&table_name, count, "remote");
+    }
+
+    Ok((known, changeset))
+}
+
+pub fn process_complete_version(
+    clock: &Clock,
+    sp: &sqlite_pool::InterruptibleTransaction<rusqlite::Savepoint<'_>>,
+    actor_id: ActorId,
+    versions: CrsqlDbVersionRange,
+    parts: ChangesetParts,
+    changes_per_table: &mut BTreeMap<String, u64>,
+) -> rusqlite::Result<(KnownDbVersion, Changeset)> {
+    let ChangesetParts {
+        version,
+        changes,
+        seqs,
+        last_seq,
+        ts,
+    } = parts;
+
+    let len = changes.len();
+
+    // TODO: Figure out a better assertion. This assertion is disabled for now to reduce false negatives. We can receive a valid complete changeset
+    // where the number of changes is less than the seqs range because some rows have been overridden by a newer update.
+    // let details = json!({"len": len, "seqs": seqs.start_int(), "seqs_end": seqs.end_int(), "actor_id": actor_id, "version": version});
+    // assert_always!(
+    //     len <= seqs.len(),
+    //     "number of changes is equal to the seq len",
+    //     &details
+    // );
+    debug_assert!(
+        len <= seqs.len(),
+        "change from actor {actor_id} version {version} has len {len} but seqs range is {seqs:?} and last_seq is {last_seq}"
+    );
+
+    // Insert all the changes in a single statement
+    // This will return a non zero rowid only if the change impacted the database
+    let mut stmt = sp.prepare_cached(
+        r#"
+    INSERT INTO crsql_changes ("table", pk, cid, val, col_version, db_version, site_id, cl, seq, ts)
+        SELECT value0, value1, value2, value3, value4, value5, value6, value7, value8, value9
+        FROM unnest(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        -- WARNING: This returns a row BEFORE inserting not after
+        RETURNING db_version, seq, last_insert_rowid()
+    "#,
+    )?;
+    let params = rusqlite::params![
+        unnest_param(changes.iter().map(|c| c.table.as_str())),
+        unnest_param(changes.iter().map(|c| &c.pk)),
+        unnest_param(changes.iter().map(|c| c.cid.as_str())),
+        unnest_param(changes.iter().map(|c| &c.val)),
+        unnest_param(changes.iter().map(|c| &c.col_version)),
+        unnest_param(changes.iter().map(|c| &c.db_version)),
+        unnest_param(changes.iter().map(|c| &c.site_id)),
+        unnest_param(changes.iter().map(|c| &c.cl)),
+        unnest_param(changes.iter().map(|c| &c.seq)),
+        unnest_param(changes.iter().map(|_| &ts)),
+    ];
+    let mut last_rowids = stmt
+        .query_map(params, |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+        .collect::<rusqlite::Result<Vec<(CrsqlDbVersion, CrsqlSeq, i64)>>>()?;
+
+    let last_rowids_len = last_rowids.len();
+
+    // RETURNING returns rows BEFORE the insert, not after
+    // so the rowids we get will be shifted by one
+    // we need to shift them back
+    if last_rowids_len > 0 {
+        for i in 0..(last_rowids_len - 1) {
+            last_rowids[i].2 = last_rowids[i + 1].2;
+        }
+        last_rowids[last_rowids_len - 1].2 = sp
+            .prepare_cached("SELECT last_insert_rowid()")?
+            .query_row(rusqlite::params![], |row| row.get(0))?;
+    }
+
+    // Now determine which exact changes impacted the database
+    // This is mostly for keeping accurate metrics
+    let mut impactful_changeset = vec![];
+    for (change, (db_version, seq, rowid)) in changes.into_iter().zip(last_rowids) {
+        // Those asserts are only a sanity check
+        assert!(db_version == change.db_version);
+        assert!(seq == change.seq);
+
+        if rowid == 0 {
+            continue;
+        }
+
+        let table_name = change.table.0.to_string();
+        impactful_changeset.push(change);
+        *changes_per_table.entry(table_name).or_default() += 1;
+    }
+
+    let (known_version, new_changeset) = if impactful_changeset.is_empty() {
+        (
+            KnownDbVersion::Cleared,
+            Changeset::Empty {
+                versions,
+                ts: Some(clock.new_timestamp()),
+            },
+        )
+    } else {
+        (
+            KnownDbVersion::Current(CurrentVersion {
+                db_version: version,
+                last_seq,
+                ts,
+            }),
+            Changeset::Full {
+                version,
+                changes: impactful_changeset,
+                seqs,
+                last_seq,
+                ts,
+            },
+        )
+    };
+
+    Ok((known_version, new_changeset))
+}
+
+pub fn process_incomplete_version(
+    sp: &sqlite_pool::InterruptibleTransaction<rusqlite::Savepoint<'_>>,
+    parts: &ChangesetParts,
+    changes_per_table: &mut BTreeMap<String, u64>,
+) -> rusqlite::Result<KnownDbVersion> {
+    let ChangesetParts {
+        changes,
+        seqs,
+        last_seq,
+        ts,
+        ..
+    } = parts;
+
+    let mut stmt = sp.prepare_cached(
+                r#"
+                INSERT INTO __corro_buffered_changes
+                    ("table", pk, cid, val, col_version, db_version, site_id, cl, seq, ts)
+                SELECT
+                    value0, value1, value2, value3, value4, value5, value6, value7, value8, value9
+                FROM
+                    unnest(:table_arr, :pk_arr, :cid_arr, :val_arr, :col_version_arr, :db_version_arr, :site_id_arr, :cl_arr, :seq_arr, :ts_arr)
+                -- Otherwise sqlite will think ON CONFLICT is part of a JOIN
+                WHERE TRUE
+                ON CONFLICT (site_id, db_version, seq)
+                    DO NOTHING
+                RETURNING
+                    "table"
+            "#,
+            )?;
+    let table_names = stmt.query_map(
+        rusqlite::named_params! {
+            ":table_arr": unnest_param(changes.iter().map(|change| change.table.as_str())),
+            ":pk_arr": unnest_param(changes.iter().map(|change| &change.pk)),
+            ":cid_arr": unnest_param(changes.iter().map(|change| change.cid.as_str())),
+            ":val_arr": unnest_param(changes.iter().map(|change| &change.val)),
+            ":col_version_arr": unnest_param(changes.iter().map(|change| change.col_version)),
+            ":db_version_arr": unnest_param(changes.iter().map(|change| change.db_version)),
+            ":site_id_arr": unnest_param(changes.iter().map(|change| &change.site_id)),
+            ":cl_arr": unnest_param(changes.iter().map(|change| change.cl)),
+            ":seq_arr": unnest_param(changes.iter().map(|change| change.seq)),
+            ":ts_arr": unnest_param(changes.iter().map(|_| ts)),
+        },
+        |row| row.get::<_, String>(0),
+    )?;
+
+    for res in table_names {
+        let tn = res?;
+        *changes_per_table.entry(tn).or_default() += 1;
+    }
+
+    Ok(KnownDbVersion::Partial(PartialVersion {
+        seqs: RangeInclusiveSet::from_iter([(*seqs).into()]),
+        last_seq: *last_seq,
+        ts: *ts,
+    }))
+}

--- a/crates/corrosion/src/gossip/changes.rs
+++ b/crates/corrosion/src/gossip/changes.rs
@@ -1,3 +1,5 @@
+mod throttle;
+
 use super::{ChangeAndSource, GossipMetrics};
 use crate::Clock;
 use corro_types::{
@@ -8,12 +10,14 @@ use corro_types::{
     broadcast::{self as bx, ChangeV1, Changeset, ChangesetParts},
     sqlite::unnest_param,
 };
+use futures::StreamExt;
 use rangemap::RangeInclusiveSet;
 use std::{
     collections::{BTreeMap, HashSet, VecDeque},
     time::{Duration, Instant},
 };
 use tokio::sync::mpsc;
+use tracing::Instrument;
 
 /// State for dynamic batch processing
 struct HandleChangesState {
@@ -268,6 +272,7 @@ impl HandleChangesState {
     }
 }
 
+#[derive(Clone)]
 pub struct ChangeOptions {
     /// How many unapplied changesets corrosion will buffer before starting to drop them
     pub processing_queue_len: usize,
@@ -303,11 +308,6 @@ impl Default for ChangeOptions {
     }
 }
 
-pub enum ClearVersionRange {
-    Single(CrsqlDbVersionRange),
-    Set(RangeInclusiveSet<CrsqlDbVersion>),
-}
-
 #[derive(Clone)]
 pub struct ChangeCtx {
     pub pool: agent::SplitPool,
@@ -317,10 +317,22 @@ pub struct ChangeCtx {
     pub actor_id: ActorId,
     pub clock: Clock,
     pub bcast_tx: mpsc::Sender<bx::BroadcastInput>,
-    pub apply_tx: mpsc::Sender<(ActorId, Vec<CrsqlDbVersion>)>,
-    pub clear_buf_tx: mpsc::Sender<(ActorId, ClearVersionRange)>,
+    pub apply_tx: mpsc::Sender<ChangeApply>,
+    pub clear_buf_tx: mpsc::Sender<(ActorId, RangeInclusiveSet<CrsqlDbVersion>)>,
     pub shutdown: tokio::sync::watch::Sender<()>,
     pub metrics: &'static super::GossipMetrics,
+}
+
+/// Spawns a task for [`handle_changes`]
+pub fn spawn_changes_handler(
+    ctx: ChangeCtx,
+    opts: ChangeOptions,
+    changes_rx: mpsc::Receiver<super::Change>,
+    tripwire: tripwire::Tripwire,
+) {
+    spawn::spawn_counted(async move {
+        handle_changes(ctx, opts, changes_rx, tripwire).await;
+    });
 }
 
 /// Bundle incoming changes to optimise transaction sizes with `SQLite`
@@ -332,7 +344,7 @@ pub struct ChangeCtx {
 pub async fn handle_changes(
     ctx: ChangeCtx,
     opts: ChangeOptions,
-    mut rx_changes: mpsc::Receiver<super::Change>,
+    mut changes_rx: mpsc::Receiver<super::Change>,
     mut tripwire: tripwire::Tripwire,
 ) {
     // Initialize batch processor state
@@ -369,7 +381,7 @@ pub async fn handle_changes(
             },
 
             // New changes arrive
-            maybe_change_src = rx_changes.recv() => match maybe_change_src {
+            maybe_change_src = changes_rx.recv() => match maybe_change_src {
                 Some(change) => change,
                 None => break,
             },
@@ -779,10 +791,10 @@ async fn process_multiple_changes(
                 }
             }
 
-            // the corrosion code doesn't seem to think this one isn't critical, or that it won't usually ever be full?
+            // the corrosion code seems to think this one isn't critical, or that it won't usually ever be full?
             if ctx
                 .clear_buf_tx
-                .try_send((actor_id, ClearVersionRange::Set(clear_versions)))
+                .try_send((actor_id, clear_versions))
                 .is_err()
             {
                 tracing::warn!("could not schedule buffered meta clear");
@@ -851,7 +863,7 @@ fn process_single_version(
     Ok((known, changeset))
 }
 
-pub fn process_complete_version(
+fn process_complete_version(
     clock: &Clock,
     sp: &sqlite_pool::InterruptibleTransaction<rusqlite::Savepoint<'_>>,
     actor_id: ActorId,
@@ -960,7 +972,7 @@ pub fn process_complete_version(
     Ok((known_version, new_changeset))
 }
 
-pub fn process_incomplete_version(
+fn process_incomplete_version(
     sp: &sqlite_pool::InterruptibleTransaction<rusqlite::Savepoint<'_>>,
     parts: &ChangesetParts,
     changes_per_table: &mut BTreeMap<String, u64>,
@@ -1015,4 +1027,580 @@ pub fn process_incomplete_version(
         last_seq: *last_seq,
         ts: *ts,
     }))
+}
+
+pub type ChangeApply = (ActorId, Vec<CrsqlDbVersion>);
+
+fn match_changes_from_db_version<H>(
+    manager: &impl corro_types::updates::Manager<H>,
+    conn: &rusqlite::Connection,
+    db_version: CrsqlDbVersion,
+    actor_id: ActorId,
+) -> rusqlite::Result<()>
+where
+    H: corro_types::updates::Handle + Send + 'static,
+{
+    let handles = manager.get_handles();
+    if handles.is_empty() {
+        return Ok(());
+    }
+
+    let mut candidates = handles
+        .iter()
+        .map(|(id, handle)| (id, (corro_types::pubsub::MatchCandidates::new(), handle)))
+        .collect::<BTreeMap<_, _>>();
+
+    {
+        let mut prepped = conn.prepare_cached(
+            r#"
+        SELECT "table", pk, cid, cl
+            FROM crsql_changes
+            WHERE db_version = ?
+              AND site_id = ?
+            ORDER BY seq ASC
+        "#,
+        )?;
+
+        let rows = prepped.query_map((db_version, actor_id), |row| {
+            Ok((
+                row.get::<_, corro_api_types::TableName>(0)?,
+                row.get::<_, Vec<u8>>(1)?,
+                row.get::<_, corro_api_types::ColumnName>(2)?,
+                row.get::<_, i64>(3)?,
+            ))
+        })?;
+
+        for change_res in rows {
+            let (table, pk, column, cl) = change_res?;
+
+            for (_id, (candidates, handle)) in candidates.iter_mut() {
+                let change = corro_types::pubsub::MatchableChange {
+                    table: &table,
+                    pk: &pk,
+                    column: &column,
+                    cl,
+                };
+                handle.filter_matchable_change(candidates, change);
+            }
+        }
+    }
+
+    // The original corrosion code spawns individual tasks for each case of the channel being full or closed, we just spawn
+    // a single task for each category
+    let mut full = Vec::new();
+    let mut closed = Vec::new();
+
+    for (id, (candidates, handle)) in candidates {
+        let mut match_count = 0;
+        for (table, pks) in candidates.iter() {
+            let count = pks.len();
+            match_count += count;
+            handle
+                .get_counter(table)
+                .matched_count
+                .increment(pks.len() as u64);
+        }
+
+        tracing::trace!(sub_id = %id, %db_version, match_count, "found candidates");
+
+        let Err(err) = handle.changes_tx().try_send(candidates) else {
+            continue;
+        };
+
+        match err {
+            mpsc::error::TrySendError::Full(item) => {
+                full.push((handle.changes_tx(), item));
+            }
+            mpsc::error::TrySendError::Closed(_) => {
+                let Some(handle) = manager.remove(id) else {
+                    continue;
+                };
+
+                closed.push(handle);
+            }
+        }
+    }
+
+    if !full.is_empty() {
+        tokio::spawn(async move {
+            let total = full.len();
+
+            let start = Instant::now();
+
+            let mut sends = futures::stream::iter(
+                full.into_iter()
+                    .map(|(tx, item)| async move { tx.send(item).await }),
+            )
+            .buffer_unordered(10);
+
+            let mut errors = 0;
+
+            while let Some(res) = sends.next().await {
+                if res.is_err() {
+                    errors += 1;
+                }
+            }
+
+            tracing::debug!(total, errors, elapsed = ?start.elapsed(), "asynchronously sent changes to channels which were full");
+        });
+    }
+
+    if !closed.is_empty() {
+        tokio::spawn(async move {
+            for handle in closed {
+                handle.cleanup().await;
+            }
+        });
+    }
+
+    Ok(())
+}
+
+async fn process_fully_buffered_changes(
+    ctx: &ChangeCtx,
+    bookie: &Bookie,
+    actor_id: ActorId,
+    version: CrsqlDbVersion,
+    tx_timeout: Duration,
+) -> Result<bool, ChangeError> {
+    let rows_impacted = {
+        let booked = bookie.ensure(actor_id);
+        let mut conn = ctx.pool.write_normal().await?;
+        tracing::trace!(%actor_id, %version, "acquired write (normal) connection to process fully buffered changes");
+
+        tokio::task::block_in_place(move || {
+            let bookie_write = bookie.write_lock_blocking();
+            let bookedw = bookie_write.write_tx(&booked);
+            tracing::trace!(%actor_id, %version, "acquired Booked write lock to process fully buffered changes");
+
+            let mut bookedw = bookedw;
+            let last_seq = {
+                match bookedw.partials.get(&version) {
+                    Some(PartialVersion { seqs, last_seq, .. }) => {
+                        if seqs.gaps(&(CrsqlSeq(0)..=*last_seq)).count() != 0 {
+                            let gaps = seqs
+                                .gaps(&(CrsqlSeq(0)..=*last_seq))
+                                .collect::<RangeInclusiveSet<CrsqlSeq>>();
+                            tracing::error!(%actor_id, %version, ?gaps, "found sequence gaps, aborting!", );
+                            // TODO: return an error here
+                            return Ok(false);
+                        }
+                        *last_seq
+                    }
+                    None => {
+                        tracing::warn!(%actor_id, %version, "version not found in cache, returning");
+                        return Ok(false);
+                    }
+                }
+            };
+
+            let base_tx = conn
+                .immediate_transaction()
+                .map_err(|source| ChangeError::Rusqlite {
+                    source,
+                    actor_id: Some(actor_id),
+                    version: Some(version),
+                })?;
+
+            let tx = sqlite_pool::InterruptibleTransaction::new(
+                base_tx,
+                Some(tx_timeout),
+                "process_buffered_changes",
+            );
+
+            tracing::trace!(%actor_id, %version, %last_seq, "Processing buffered changes to crsql_changes");
+
+            let rows_present: bool = tx.prepare_cached("SELECT EXISTS (SELECT 1 FROM __corro_buffered_changes WHERE site_id = ? AND db_version = ?)")
+                                    .map_err(|source| ChangeError::Rusqlite{source, actor_id: Some(actor_id), version: Some(version)})?
+                                    .query_row(rusqlite::params![actor_id, version], |row| row.get(0))
+                                    .map_err(|source| ChangeError::Rusqlite{source, actor_id: Some(actor_id), version: Some(version)})?;
+
+            let start = Instant::now();
+
+            if rows_present {
+                // insert all buffered changes into crsql_changes directly from the buffered changes table
+                let count = tx
+                    .prepare_cached(
+                        r#"
+                        INSERT INTO crsql_changes ("table", pk, cid, val, col_version, db_version, site_id, cl, seq, ts)
+                            SELECT                 "table", pk, cid, val, col_version, db_version, site_id, cl, seq, ts
+                                FROM __corro_buffered_changes
+                                    WHERE site_id = ?
+                                    AND db_version = ?
+                                    ORDER BY db_version ASC, seq ASC
+                                    "#,
+                    ).map_err(|source| ChangeError::Rusqlite{source, actor_id: Some(actor_id), version: Some(version)})?
+                    .execute(rusqlite::params![actor_id.as_bytes(), version]).map_err(|source| ChangeError::Rusqlite{source, actor_id: Some(actor_id), version: Some(version)})?;
+                tracing::trace!(%actor_id, %version, count, elapsed = ?start.elapsed(), "Inserted rows from buffered into crsql_changes");
+            } else {
+                tracing::trace!(%actor_id, %version, "No buffered rows, skipped insertion into crsql_changes");
+            }
+
+            let rows_impacted: i64 = tx
+                .prepare_cached("SELECT crsql_rows_impacted()")
+                .map_err(|source| ChangeError::Rusqlite {
+                    source,
+                    actor_id: Some(actor_id),
+                    version: Some(version),
+                })?
+                .query_row((), |row| row.get(0))
+                .map_err(|source| ChangeError::Rusqlite {
+                    source,
+                    actor_id: Some(actor_id),
+                    version: Some(version),
+                })?;
+
+            tracing::trace!(%actor_id, %version, rows_impacted, "rows impacted by buffered changes insertion");
+
+            bookedw
+                .insert_db(&tx, [version..=version].into())
+                .map_err(|source| ChangeError::Rusqlite {
+                    source,
+                    actor_id: Some(actor_id),
+                    version: Some(version),
+                })?;
+
+            // the version transitions from partial → fully applied, clean up its seq bookkeeping
+            bookedw
+                .clear_partials(&tx, RangeInclusiveSet::from([version..=version]))
+                .map_err(|source| ChangeError::Rusqlite {
+                    source,
+                    actor_id: Some(actor_id),
+                    version: Some(version),
+                })?;
+
+            tx.commit().map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: Some(actor_id),
+                version: Some(version),
+            })?;
+
+            bookedw.commit();
+
+            if let Err(error) = ctx
+                .clear_buf_tx
+                .try_send((actor_id, rangemap::range_inclusive_set![version..=version]))
+            {
+                tracing::error!(%error, "could not schedule buffered data clear");
+            }
+
+            Ok::<_, ChangeError>(rows_impacted > 0)
+        })
+    }?;
+
+    if rows_impacted {
+        let conn = ctx.pool.read().await?;
+        tokio::task::block_in_place(|| {
+            if let Err(error) =
+                match_changes_from_db_version(&ctx.sub_manager, &conn, version, actor_id)
+            {
+                tracing::error!(%error, %version, "could not match changes for subs from db version");
+            }
+        });
+
+        tokio::task::block_in_place(|| {
+            if let Err(error) =
+                match_changes_from_db_version(&ctx.update_manager, &conn, version, actor_id)
+            {
+                tracing::error!(%error, %version, "could not match changes for updates from db version");
+            }
+        });
+    }
+
+    Ok(rows_impacted)
+}
+
+pub fn spawn_buffered_apply(
+    ctx: ChangeCtx,
+    opts: ChangeOptions,
+    bookie: Bookie,
+    mut apply_rx: mpsc::Receiver<ChangeApply>,
+    mut tripwire: tripwire::Tripwire,
+) {
+    async fn find_fully_buffered_partial(
+        pool: &corro_types::agent::SplitPool,
+    ) -> Result<Option<(ActorId, CrsqlDbVersion)>, ChangeError> {
+        let conn = pool.read().await.map_err(ChangeError::SqlitePool)?;
+
+        tokio::task::block_in_place(|| {
+            conn.prepare_cached(
+                "SELECT site_id, db_version FROM __corro_seq_bookkeeping
+                 WHERE start_seq = 0 AND end_seq = last_seq
+                 LIMIT 1",
+            )
+            .and_then(
+                |mut stmt| match stmt.query_row([], |row| Ok((row.get(0)?, row.get(1)?))) {
+                    Ok(v) => Ok(Some(v)),
+                    Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                    Err(e) => Err(e),
+                },
+            )
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: None,
+                version: None,
+            })
+        })
+    }
+
+    spawn::spawn_counted(async move {
+        // we can burst timeout up to an additional 2 min
+        let max_timeout_increase: u64 = 6;
+        let step_timeout_secs: u64 = 20;
+
+        let throttle_min = Duration::from_secs(5 * 60);
+        let throttle_max = Duration::from_secs(60 * 60);
+
+        let mut retry_interval = tokio::time::interval(Duration::from_secs(5 * 60));
+
+        // map to throttle retries for failed versions that took too long to apply
+        let mut limit_retries = throttle::ThrottleMap::new(throttle_min, throttle_max);
+
+        let do_process =
+            async |partial_version: (ActorId, CrsqlDbVersion),
+                   limit_retries: &mut throttle::ThrottleMap| {
+                async {
+                if let Some(blocked_until) = limit_retries.is_throttled(&partial_version) {
+                    let next_retry = blocked_until.duration_since(Instant::now());
+                    tracing::debug!(
+                        ?next_retry,
+                        "previous attempt to apply buffered changes took too long, will retry"
+                    );
+                    return;
+                }
+
+                let throttle_count = limit_retries
+                    .throttle_count(&partial_version)
+                    .min(max_timeout_increase);
+                let tx_timeout =
+                    opts.sql_tx_timeout + Duration::from_secs(step_timeout_secs * throttle_count);
+
+                tracing::debug!(?tx_timeout, "picked up buffered changes");
+
+                let start = Instant::now();
+                let res =
+                    process_fully_buffered_changes(&ctx, &bookie, partial_version.0, partial_version.1, tx_timeout)
+                        .await;
+                let elapsed = start.elapsed();
+                match res {
+                    Ok(false) => {
+                        tracing::debug!("did not apply buffered changes");
+                        limit_retries.remove(&partial_version);
+                    }
+                    Ok(true) => {
+                        tracing::debug!("succesfully applied buffered changes");
+                        ctx.metrics.changes_processed(elapsed, "buffered", None);
+                        limit_retries.remove(&partial_version);
+                    }
+                    Err(error) => {
+                        let is_interrupt_error = error.is_interrupt_error();
+                        tracing::debug!(elapsed = ?tx_timeout, %error, "could not apply fully buffered changes");
+                        if let Some(issue) = error.fatal_db_issue() {
+                            super::fatal_db_issue(issue, &ctx.shutdown);
+                        }
+
+                        // processing time came close to timeout, limit retry with exponential backoff
+                        if is_interrupt_error {
+                            limit_retries.throttle(partial_version);
+                        }
+                    }
+                }
+            }.instrument(tracing::debug_span!("background apply", actor_id = %partial_version.0, version = %partial_version.1)).await;
+            };
+
+        retry_interval.tick().await;
+
+        loop {
+            // TODO: The original corrosion code was sending one change at a time but I changed it so it was n changes per
+            // actor instead which would be beneficial in this write code by consolidating DB access
+            tokio::select! {
+                biased;
+                _ = &mut tripwire => break,
+                maybe_version = apply_rx.recv() => {
+                    let Some((actor, versions)) = maybe_version else {
+                        break;
+                    };
+
+                    for version in versions {
+                        do_process((actor, version), &mut limit_retries).await;
+                    }
+                },
+                _ = retry_interval.tick() => {
+                    match find_fully_buffered_partial(&ctx.pool).await {
+                        Ok(Some(pair)) => {
+                            do_process(pair, &mut limit_retries).await;
+                        }
+                        Ok(None) => {}
+                        Err(error) => {
+                            tracing::debug!(%error, "could not query for fully buffered partials");
+                        },
+                    }
+                },
+            }
+        }
+    });
+}
+
+/// Clean up `__corro_buffered_changes` rows for versions that have been fully applied.
+/// `__corro_seq_bookkeeping` is managed through the bookie via `insert_partials_db`/`insert_db`.
+pub fn spawn_buffered_cleanup(
+    ctx: ChangeCtx,
+    opts: ChangeOptions,
+    mut clear_buf_rx: mpsc::Receiver<(ActorId, RangeInclusiveSet<CrsqlDbVersion>)>,
+    mut tripwire: tripwire::Tripwire,
+) {
+    async fn find_orphaned_buffered_changes(
+        pool: &corro_types::agent::SplitPool,
+    ) -> Result<Option<(ActorId, CrsqlDbVersion)>, ChangeError> {
+        let conn = pool.read().await.map_err(ChangeError::SqlitePool)?;
+        tokio::task::block_in_place(|| {
+            conn.prepare_cached(
+                "SELECT DISTINCT bc.site_id, bc.db_version
+                 FROM __corro_buffered_changes bc
+                 WHERE NOT EXISTS (
+                     SELECT 1 FROM __corro_seq_bookkeeping bk
+                     WHERE bk.site_id = bc.site_id AND bk.db_version = bc.db_version
+                 )
+                 LIMIT 1",
+            )
+            .and_then(
+                |mut stmt| match stmt.query_row([], |row| Ok((row.get(0)?, row.get(1)?))) {
+                    Ok(v) => Ok(Some(v)),
+                    Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+                    Err(e) => Err(e),
+                },
+            )
+            .map_err(|source| ChangeError::Rusqlite {
+                source,
+                actor_id: None,
+                version: None,
+            })
+        })
+    }
+
+    spawn::spawn_counted(async move {
+        // check for orphaned buffered changes every 5 minutes
+        let mut retry_interval = tokio::time::interval(Duration::from_secs(5 * 60));
+        retry_interval.tick().await;
+
+        loop {
+            let (actor_id, versions) = tokio::select! {
+                biased;
+                _ = &mut tripwire => break,
+                maybe_partials = clear_buf_rx.recv() => {
+                    let Some(partials) = maybe_partials else {
+                        break;
+                    };
+
+                    partials
+                }
+                _ = retry_interval.tick() => {
+                    match find_orphaned_buffered_changes(&ctx.pool).await {
+                        Ok(Some((actor_id, version))) => (actor_id, rangemap::range_inclusive_set![version..=version]),
+                        Ok(None) => continue,
+                        Err(error) => {
+                            tracing::debug!(%error, "could not query for orphaned buffered changes");
+                            continue;
+                        }
+                    }
+                }
+            };
+
+            let to_clear = if let Some(booked) = ctx.bookie.get(&actor_id) {
+                let booked_read = booked.read();
+                // The original corrosion code seems to have a bug where a continue is done on the inner loop instead of the
+                // outer loop
+                // for version in versions {
+                //     if booked_read.get_partial(&version).is_some() {
+                //         warn!(%actor_id, %version, "clear_buffered_meta: received partial version that's still in bookie, skipping");
+                //         continue;
+                //     }
+                // }
+
+                let before = versions.len();
+                let to_clear: rangemap::RangeInclusiveSet<_> = versions
+                    .into_iter()
+                    .filter(|v| {
+                        for v in v.start().0..=v.end().0 {
+                            if booked_read.get_partial(&CrsqlDbVersion(v)).is_some() {
+                                return false;
+                            }
+                        }
+
+                        true
+                    })
+                    .collect();
+
+                if to_clear.is_empty() {
+                    tracing::debug!(%actor_id, "received set of partial versions that were all still in the bookie, skipping");
+                    continue;
+                } else if before > to_clear.len() {
+                    tracing::debug!(%actor_id, still_booked = before - to_clear.len(), "received set of partial versions, some of which were still booked");
+                }
+
+                to_clear
+            } else {
+                versions
+            };
+
+            let pool = ctx.pool.clone();
+            let tx_timeout = opts.sql_tx_timeout;
+            let self_actor_id = ctx.actor_id;
+            let mut task_tripwire = tripwire.clone();
+
+            const TO_CLEAR_COUNT: usize = 1000;
+
+            spawn::spawn_counted(async move {
+                loop {
+                    let res = {
+                        let mut conn = pool.write_low().await?;
+
+                        tokio::task::block_in_place(|| {
+                            let tx = sqlite_pool::InterruptibleTransaction::new(
+                                conn.immediate_transaction()?,
+                                Some(tx_timeout),
+                                "clear_buffered_meta",
+                            );
+
+                            let mut buf_count = 0;
+
+                            for range in to_clear {
+                                buf_count += tx
+                                .prepare_cached("DELETE FROM __corro_buffered_changes WHERE (site_id, db_version, seq) IN (SELECT site_id, db_version, seq FROM __corro_buffered_changes WHERE site_id = ? AND db_version >= ? AND db_version <= ? LIMIT ?)")?
+                                .execute(rusqlite::params![actor_id, range.start().0, range.end().0, TO_CLEAR_COUNT])?;
+                            }
+
+                            tx.commit()?;
+
+                            Ok::<_, rusqlite::Error>(buf_count)
+                        })
+                    };
+
+                    match res {
+                        Ok(buf_count) => {
+                            if buf_count > 0 {
+                                tracing::debug!(buf_count, "cleared buffered change rows");
+                            }
+                            if buf_count < TO_CLEAR_COUNT {
+                                break;
+                            }
+                        }
+                        Err(error) => {
+                            tracing::debug!(%error, "could not clear buffered meta for versions");
+                        }
+                    }
+
+                    // TODO: Why do we sleep here?
+                    tokio::select! {
+                        _ = &mut task_tripwire => {
+                            break;
+                        }
+                        _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+                    }
+                }
+
+                Ok::<_, eyre::Report>(())
+            }.instrument(tracing::debug_span!("clear buffered version", %actor_id, %self_actor_id)));
+        }
+    });
 }

--- a/crates/corrosion/src/gossip/changes.rs
+++ b/crates/corrosion/src/gossip/changes.rs
@@ -869,14 +869,6 @@ pub fn process_complete_version(
 
     let len = changes.len();
 
-    // TODO: Figure out a better assertion. This assertion is disabled for now to reduce false negatives. We can receive a valid complete changeset
-    // where the number of changes is less than the seqs range because some rows have been overridden by a newer update.
-    // let details = json!({"len": len, "seqs": seqs.start_int(), "seqs_end": seqs.end_int(), "actor_id": actor_id, "version": version});
-    // assert_always!(
-    //     len <= seqs.len(),
-    //     "number of changes is equal to the seq len",
-    //     &details
-    // );
     debug_assert!(
         len <= seqs.len(),
         "change from actor {actor_id} version {version} has len {len} but seqs range is {seqs:?} and last_seq is {last_seq}"

--- a/crates/corrosion/src/gossip/changes.rs
+++ b/crates/corrosion/src/gossip/changes.rs
@@ -1174,24 +1174,21 @@ async fn process_fully_buffered_changes(
             tracing::trace!(%actor_id, %version, "acquired Booked write lock to process fully buffered changes");
 
             let mut bookedw = bookedw;
-            let last_seq = {
-                match bookedw.partials.get(&version) {
-                    Some(PartialVersion { seqs, last_seq, .. }) => {
-                        if seqs.gaps(&(CrsqlSeq(0)..=*last_seq)).count() != 0 {
-                            let gaps = seqs
-                                .gaps(&(CrsqlSeq(0)..=*last_seq))
-                                .collect::<RangeInclusiveSet<CrsqlSeq>>();
-                            tracing::error!(%actor_id, %version, ?gaps, "found sequence gaps, aborting!", );
-                            // TODO: return an error here
-                            return Ok(false);
-                        }
-                        *last_seq
-                    }
-                    None => {
-                        tracing::warn!(%actor_id, %version, "version not found in cache, returning");
-                        return Ok(false);
-                    }
+            let last_seq = if let Some(PartialVersion { seqs, last_seq, .. }) =
+                bookedw.partials.get(&version)
+            {
+                if seqs.gaps(&(CrsqlSeq(0)..=*last_seq)).count() != 0 {
+                    let gaps = seqs
+                        .gaps(&(CrsqlSeq(0)..=*last_seq))
+                        .collect::<RangeInclusiveSet<CrsqlSeq>>();
+                    tracing::error!(%actor_id, %version, ?gaps, "found sequence gaps, aborting!", );
+                    // TODO: return an error here
+                    return Ok(false);
                 }
+                *last_seq
+            } else {
+                tracing::warn!(%actor_id, %version, "version not found in cache, returning");
+                return Ok(false);
             };
 
             let base_tx = conn
@@ -1518,6 +1515,8 @@ pub fn spawn_buffered_cleanup(
                 // }
 
                 let before = versions.len();
+
+                // This is a poor version of retain since rangemap does not have that functionality
                 let to_clear: rangemap::RangeInclusiveSet<_> = versions
                     .into_iter()
                     .filter(|v| {
@@ -1564,7 +1563,7 @@ pub fn spawn_buffered_cleanup(
 
                             let mut buf_count = 0;
 
-                            for range in to_clear {
+                            for range in to_clear.iter() {
                                 buf_count += tx
                                 .prepare_cached("DELETE FROM __corro_buffered_changes WHERE (site_id, db_version, seq) IN (SELECT site_id, db_version, seq FROM __corro_buffered_changes WHERE site_id = ? AND db_version >= ? AND db_version <= ? LIMIT ?)")?
                                 .execute(rusqlite::params![actor_id, range.start().0, range.end().0, TO_CLEAR_COUNT])?;
@@ -1590,7 +1589,6 @@ pub fn spawn_buffered_cleanup(
                         }
                     }
 
-                    // TODO: Why do we sleep here?
                     tokio::select! {
                         _ = &mut task_tripwire => {
                             break;

--- a/crates/corrosion/src/gossip/changes.rs
+++ b/crates/corrosion/src/gossip/changes.rs
@@ -1073,7 +1073,7 @@ where
         for change_res in rows {
             let (table, pk, column, cl) = change_res?;
 
-            for (_id, (candidates, handle)) in candidates.iter_mut() {
+            for (candidates, handle) in candidates.values_mut() {
                 let change = corro_types::pubsub::MatchableChange {
                     table: &table,
                     pk: &pk,

--- a/crates/corrosion/src/gossip/changes/throttle.rs
+++ b/crates/corrosion/src/gossip/changes/throttle.rs
@@ -1,0 +1,104 @@
+use std::time::{Duration, Instant};
+
+type Change = (
+    corro_types::actor::ActorId,
+    corro_types::base::CrsqlDbVersion,
+);
+
+#[derive(Clone)]
+struct ThrottleEntry {
+    blocked_until: Instant,
+    throttle_count: u32,
+}
+
+/// Per-key exponential throttle: each [`Self:.throttle`] increases the wait from
+/// `throttle_min` by powers of two until `throttle_max`. [`Self::retries`] count the number of
+/// times the key has been throttled).
+pub(super) struct ThrottleMap {
+    inner: std::collections::HashMap<Change, ThrottleEntry>,
+    throttle_min: Duration,
+    throttle_max: Duration,
+
+    max_pow: u32,
+}
+
+#[inline]
+fn exponential_increase(pow: u32, throttle_min: Duration, throttle_max: Duration) -> Duration {
+    let mult = 1u32.checked_shl(pow).unwrap_or(u32::MAX);
+    (throttle_min * mult).min(throttle_max)
+}
+
+#[inline]
+fn max_pow(throttle_min: Duration, throttle_max: Duration) -> u32 {
+    if throttle_min > throttle_max {
+        return 0;
+    }
+    let ratio = if throttle_min.is_zero() {
+        throttle_max.as_nanos()
+    } else {
+        throttle_max.as_nanos() / throttle_min.as_nanos()
+    };
+    ratio.ilog2()
+}
+
+impl ThrottleMap {
+    pub(super) fn new(throttle_min: Duration, throttle_max: Duration) -> Self {
+        Self {
+            inner: Default::default(),
+            throttle_min,
+            throttle_max,
+            max_pow: max_pow(throttle_min, throttle_max),
+        }
+    }
+
+    #[inline]
+    pub(super) fn is_throttled(&self, key: &Change) -> Option<Instant> {
+        if let Some(e) = self.inner.get(key)
+            && Instant::now() < e.blocked_until
+        {
+            return Some(e.blocked_until);
+        }
+
+        None
+    }
+
+    #[inline]
+    pub fn throttle_count(&self, key: &Change) -> u64 {
+        self.inner
+            .get(key)
+            .map(|e| e.throttle_count as u64)
+            .unwrap_or(0)
+    }
+
+    #[inline]
+    pub fn throttle(&mut self, key: Change) {
+        let now = Instant::now();
+        let entry = self.inner.entry(key).or_insert(ThrottleEntry {
+            blocked_until: now,
+            throttle_count: 0,
+        });
+
+        // we calculate max pow so we can clamp things and not worry about overflow
+        let pow = entry.throttle_count.min(self.max_pow);
+        let wait = exponential_increase(pow, self.throttle_min, self.throttle_max);
+
+        entry.blocked_until = now + wait;
+        entry.throttle_count = entry.throttle_count.saturating_add(1);
+    }
+
+    // #[inline]
+    // pub fn clear_expired(&mut self) {
+    //     let now = Instant::now();
+    //     self.inner.retain(|_, entry| entry.blocked_until > now);
+    // }
+
+    #[inline]
+    pub fn remove(&mut self, key: &Change) {
+        self.inner.remove(key);
+    }
+
+    // #[inline]
+    // pub fn contains(&self, key: &Change) -> bool {
+    //     self.inner.contains_key(key)
+    // }
+}

--- a/crates/corrosion/src/gossip/changes/throttle.rs
+++ b/crates/corrosion/src/gossip/changes/throttle.rs
@@ -64,10 +64,7 @@ impl ThrottleMap {
 
     #[inline]
     pub fn throttle_count(&self, key: &Change) -> u64 {
-        self.inner
-            .get(key)
-            .map(|e| e.throttle_count as u64)
-            .unwrap_or(0)
+        self.inner.get(key).map_or(0, |e| e.throttle_count as u64)
     }
 
     #[inline]

--- a/crates/corrosion/src/gossip/handler.rs
+++ b/crates/corrosion/src/gossip/handler.rs
@@ -1,0 +1,256 @@
+use super::GossipContext;
+use corro_types::broadcast;
+use speedy::Readable as _;
+use std::time::Duration;
+use tokio_util::codec;
+use tracing::Instrument as _;
+use tripwire::{Outcome, PreemptibleFutureExt as _, TimeoutFutureExt as _, Tripwire};
+
+/// Spawn a tree of tasks that handles incoming gossip server connections, streams, and their respective payloads.
+pub fn spawn_gossipserver_handler(
+    ctx: GossipContext,
+    mut tripwire: Tripwire,
+    gossip_server_endpoint: quinn::Endpoint,
+) {
+    spawn::spawn_counted(async move {
+        loop {
+            let incoming = match gossip_server_endpoint
+                .accept()
+                .preemptible(&mut tripwire)
+                .await
+            {
+                Outcome::Completed(Some(incoming)) => incoming,
+                Outcome::Completed(None) => return,
+                Outcome::Preempted(_) => break,
+            };
+
+            spawn_incoming_connection_handlers(ctx.clone(), tripwire.clone(), incoming);
+        }
+
+        // graceful shutdown
+        let idle = gossip_server_endpoint
+            .wait_idle()
+            .with_timeout(Duration::from_secs(5));
+        tokio::pin!(idle);
+
+        loop {
+            tokio::select! {
+                _ = &mut idle => {
+                    break;
+                }
+                incoming = gossip_server_endpoint.accept() => {
+                    // Refuse any new connections while we are gracefully shutting down
+                    if let Some(inc) = incoming {
+                        inc.refuse();
+                    }
+                }
+            }
+        }
+
+        gossip_server_endpoint.close(0u32.into(), b"shutting down");
+    });
+}
+
+/// Spawn a task which handles all state and interactions for a given
+/// incoming connection.
+///
+/// This function spawns many futures!
+pub fn spawn_incoming_connection_handlers(
+    ctx: GossipContext,
+    mut tripwire: Tripwire,
+    connecting: quinn::Incoming,
+) {
+    let remote_addr = connecting.remote_address();
+
+    tokio::spawn(
+        async move {
+            tracing::trace!("got incoming gossip connection");
+
+            let conn = match connecting.await {
+                Ok(conn) => conn,
+                Err(error) => {
+                    tracing::error!(%error, "gossip handshake failed");
+                    ctx.metrics.server_handshakes_failed_inc(&error);
+                    return;
+                }
+            };
+
+            tracing::trace!("accepted a gossip connection");
+            ctx.metrics.server_conns_inc();
+
+            loop {
+                tokio::select! {
+                    // Datagrams are used to communicate foca (SWIM) state
+                    datagram = conn.read_datagram() => {
+                        process_foca_datagram(&ctx, datagram).await;
+                    }
+                    uni = conn.accept_uni() => {
+                        process_broadcast_stream(ctx.clone(), uni, remote_addr);
+                    }
+                    bi = conn.accept_bi() => {
+                        process_sync_stream(ctx.clone(), bi, remote_addr);
+                    }
+                    _ = &mut tripwire => {
+                        tracing::debug!("connection cancelled");
+                        return;
+                    }
+                }
+            }
+        }
+        .instrument(tracing::trace_span!("gossip_connection", %remote_addr)),
+    );
+}
+
+#[inline]
+async fn process_foca_datagram(
+    ctx: &GossipContext,
+    datagram: Result<bytes::Bytes, quinn::ConnectionError>,
+) {
+    match datagram {
+        Ok(bytes) => {
+            ctx.metrics.server_datagrams_inc(&bytes);
+
+            drop(ctx.foca_tx.send(broadcast::FocaInput::Data(bytes)).await);
+        }
+        Err(error) => {
+            ctx.metrics.server_datagrams_failed_inc(&error);
+        }
+    }
+}
+
+/// Spawn a task that accepts unidirectional broadcast streams, then spawns another task for each incoming stream to handle.
+fn process_broadcast_stream(
+    ctx: GossipContext,
+    recv: Result<quinn::RecvStream, quinn::ConnectionError>,
+    remote_addr: std::net::SocketAddr,
+) {
+    let recv = match recv {
+        Ok(r) => r,
+        Err(error) => {
+            ctx.metrics
+                .server_streams_failed_inc(&error, quinn::Dir::Uni);
+            return;
+        }
+    };
+
+    tokio::spawn(async move {
+        let stream_metrics = super::StreamMetrics::uni(ctx.metrics);
+
+        let mut framed = codec::FramedRead::new(
+            recv,
+            codec::LengthDelimitedCodec::builder()
+                .max_frame_length(100 * 1_024 * 1_024)
+                .new_codec(),
+        );
+
+        let mut changes = Vec::with_capacity(1024);
+
+        loop {
+            let Some(next) = tokio_stream::StreamExt::next(&mut framed).await else {
+                break;
+            };
+
+            let next = match next {
+                Ok(n) => n,
+                Err(error) => {
+                    tracing::error!(%error, "failed to decode broadcast stream");
+                    continue;
+                }
+            };
+
+            stream_metrics.incoming(&next);
+
+            match broadcast::UniPayload::read_from_buffer(&next) {
+                Ok(broadcast::UniPayload::V1 {
+                    data: broadcast::UniPayloadV1::Broadcast(broadcast::BroadcastV1::Change(change)),
+                    cluster_id,
+                }) => {
+                    if cluster_id == ctx.cluster_id {
+                        changes.push((change, broadcast::ChangeSource::Broadcast));
+                    }
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to decode broadcast payload");
+                }
+            }
+        }
+
+        if ctx.changes_tx.send(super::Change::Bulk(changes)).await.is_err() {
+            tracing::error!("failed to send broadcast changes, receiver dropped");
+        }
+    }.instrument(tracing::trace_span!("gossip broadcast stream", %remote_addr)));
+}
+
+fn process_sync_stream(
+    ctx: GossipContext,
+    stream: Result<(quinn::SendStream, quinn::RecvStream), quinn::ConnectionError>,
+    remote_addr: std::net::SocketAddr,
+) {
+    let (send, recv) = match stream {
+        Ok(r) => r,
+        Err(error) => {
+            ctx.metrics
+                .server_streams_failed_inc(&error, quinn::Dir::Bi);
+            return;
+        }
+    };
+
+    tokio::spawn(
+        async move {
+            let stream_metrics = super::StreamMetrics::bi(ctx.metrics);
+
+            let mut framed = codec::FramedRead::new(
+                recv,
+                codec::LengthDelimitedCodec::builder()
+                    .max_frame_length(100 * 1_024 * 1_024)
+                    .new_codec(),
+            );
+
+            loop {
+                let frame = match tokio::time::timeout(
+                    Duration::from_secs(5),
+                    tokio_stream::StreamExt::next(&mut framed),
+                )
+                .await
+                {
+                    Err(_) => {
+                        tracing::warn!("timed out receiving sync frame");
+                        return;
+                    }
+                    Ok(None) => {
+                        return;
+                    }
+                    Ok(Some(Ok(p))) => p,
+                    Ok(Some(Err(error))) => {
+                        tracing::error!(%error, "failed to read frame from sync stream");
+                        continue;
+                    }
+                };
+
+                stream_metrics.incoming(&frame);
+
+                match broadcast::BiPayload::read_from_buffer(&frame) {
+                    Ok(broadcast::BiPayload::V1 {
+                        data:
+                            broadcast::BiPayloadV1::SyncStart {
+                                actor_id,
+                                trace_ctx,
+                            },
+                        cluster_id,
+                    }) => {
+                        let span = tracing::trace_span!("sync", local_actor = %ctx.actor_id, remote_actor = %actor_id);
+                        if let Err(error) = super::sync::serve_sync(ctx, stream_metrics, actor_id, cluster_id, trace_ctx, framed, send).instrument(span).await {
+                            tracing::warn!(%error, "failed to complete sync");
+                        }
+
+                        break;
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "failed to decode sync payload");
+                    }
+                }
+            }
+        }
+        .instrument(tracing::trace_span!("gossip sync stream", %remote_addr)),
+    );
+}

--- a/crates/corrosion/src/gossip/handler.rs
+++ b/crates/corrosion/src/gossip/handler.rs
@@ -1,24 +1,32 @@
 use super::GossipContext;
 use corro_types::broadcast;
 use speedy::Readable as _;
-use std::time::Duration;
+use std::{net::SocketAddr, time::Duration};
 use tokio_util::codec;
 use tracing::Instrument as _;
 use tripwire::{Outcome, PreemptibleFutureExt as _, TimeoutFutureExt as _, Tripwire};
 
 /// Spawn a tree of tasks that handles incoming gossip server connections, streams, and their respective payloads.
-pub fn spawn_gossipserver_handler(
+pub fn spawn_gossipserver_unencrypted(
     ctx: GossipContext,
     mut tripwire: Tripwire,
-    gossip_server_endpoint: quinn::Endpoint,
-) {
+    gossip_server_endpoint: SocketAddr,
+) -> std::io::Result<()> {
+    let mut cfg = quinn_plaintext::server_config();
+    let mut tcfg = quinn::TransportConfig::default();
+
+    // Note this is the same as the current default quinn idle timeout, but we specify it here again in case the default
+    // changes
+    tcfg.max_idle_timeout(Some(
+        Duration::from_secs(30).try_into().expect("unreachable"),
+    ));
+    cfg.transport_config(std::sync::Arc::new(tcfg));
+
+    let endpoint = quinn::Endpoint::server(cfg, gossip_server_endpoint)?;
+
     spawn::spawn_counted(async move {
         loop {
-            let incoming = match gossip_server_endpoint
-                .accept()
-                .preemptible(&mut tripwire)
-                .await
-            {
+            let incoming = match endpoint.accept().preemptible(&mut tripwire).await {
                 Outcome::Completed(Some(incoming)) => incoming,
                 Outcome::Completed(None) => return,
                 Outcome::Preempted(_) => break,
@@ -28,9 +36,7 @@ pub fn spawn_gossipserver_handler(
         }
 
         // graceful shutdown
-        let idle = gossip_server_endpoint
-            .wait_idle()
-            .with_timeout(Duration::from_secs(5));
+        let idle = endpoint.wait_idle().with_timeout(Duration::from_secs(5));
         tokio::pin!(idle);
 
         loop {
@@ -38,7 +44,7 @@ pub fn spawn_gossipserver_handler(
                 _ = &mut idle => {
                     break;
                 }
-                incoming = gossip_server_endpoint.accept() => {
+                incoming = endpoint.accept() => {
                     // Refuse any new connections while we are gracefully shutting down
                     if let Some(inc) = incoming {
                         inc.refuse();
@@ -47,15 +53,17 @@ pub fn spawn_gossipserver_handler(
             }
         }
 
-        gossip_server_endpoint.close(0u32.into(), b"shutting down");
+        endpoint.close(0u32.into(), b"shutting down");
     });
+
+    Ok(())
 }
 
 /// Spawn a task which handles all state and interactions for a given
 /// incoming connection.
 ///
 /// This function spawns many futures!
-pub fn spawn_incoming_connection_handlers(
+fn spawn_incoming_connection_handlers(
     ctx: GossipContext,
     mut tripwire: Tripwire,
     connecting: quinn::Incoming,
@@ -253,4 +261,40 @@ fn process_sync_stream(
         }
         .instrument(tracing::trace_span!("gossip sync stream", %remote_addr)),
     );
+}
+
+/// Spawn a single task that accepts chunks from a receiver and updates cluster member round-trip-times in the agent state.
+pub fn spawn_rtt_handler(
+    members: super::Members,
+    rtt_rx: tokio::sync::mpsc::Receiver<(SocketAddr, Duration)>,
+    mut tripwire: Tripwire,
+) {
+    use tokio_stream::StreamExt;
+
+    spawn::spawn_counted(async move {
+        let stream = tokio_stream::wrappers::ReceiverStream::new(rtt_rx);
+        // we can handle a lot of them I think...
+        let chunker = stream.chunks_timeout(1024, Duration::from_secs(1));
+        tokio::pin!(chunker);
+
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut tripwire => {
+                    break;
+                }
+                chunks = chunker.next() => {
+                    if let Some(chunks) = chunks {
+                        let mut members = members.0.write();
+                        for (addr, rtt) in chunks {
+                            members.add_rtt(addr, rtt);
+                            //histogram!("corro.transport.rtt.v2.seconds").record(rtt.as_secs_f64());
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+        }
+    });
 }

--- a/crates/corrosion/src/gossip/handler.rs
+++ b/crates/corrosion/src/gossip/handler.rs
@@ -158,7 +158,7 @@ fn process_broadcast_stream(
                 }
             };
 
-            stream_metrics.incoming(&next);
+            stream_metrics.incoming(&next, super::transport::TrafficClass::Broadcast);
 
             match broadcast::UniPayload::read_from_buffer(&next) {
                 Ok(broadcast::UniPayload::V1 {
@@ -227,7 +227,7 @@ fn process_sync_stream(
                     }
                 };
 
-                stream_metrics.incoming(&frame);
+                stream_metrics.incoming(&frame, super::transport::TrafficClass::Sync);
 
                 match broadcast::BiPayload::read_from_buffer(&frame) {
                     Ok(broadcast::BiPayload::V1 {

--- a/crates/corrosion/src/gossip/metrics.rs
+++ b/crates/corrosion/src/gossip/metrics.rs
@@ -64,6 +64,10 @@ pub struct GossipMetrics {
     client_bytes_sent: IntCounterVec,
     client_connect_time: HistogramVec,
     client_connect_errors: IntCounterVec,
+
+    member_removed: IntCounterVec,
+    member_added: IntCounter,
+    swim_notifications: IntCounterVec,
 }
 
 impl GossipMetrics {
@@ -376,6 +380,32 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
+            let member_removed = p::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_member_removed",
+                    "Number of total cluster membership removals",
+                },
+                &["reason"],
+                registry,
+            }
+            .unwrap();
+            let member_added = p::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_member_added",
+                    "Number of total cluster membership additions",
+                },
+                registry,
+            }
+            .unwrap();
+            let swim_notifications = p::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_swim_notifications",
+                    "Number of total SWIM notifications",
+                },
+                &["kind"],
+                registry,
+            }
+            .unwrap();
 
             Self {
                 active_conns,
@@ -414,6 +444,9 @@ impl GossipMetrics {
                 client_bytes_sent,
                 client_connect_time,
                 client_connect_errors,
+                member_removed,
+                member_added,
+                swim_notifications,
             }
         })
     }
@@ -621,6 +654,21 @@ impl GossipMetrics {
         self.client_bytes_sent
             .with_label_values(&[ts])
             .inc_by(len as _);
+    }
+
+    #[inline]
+    pub fn member_removed_inc(&self, reason: &str) {
+        self.member_removed.with_label_values(&[reason]).inc();
+    }
+
+    #[inline]
+    pub fn member_added_inc(&self) {
+        self.member_added.inc();
+    }
+
+    #[inline]
+    pub fn swim_notification_inc(&self, kind: &str) {
+        self.swim_notifications.with_label_values(&[kind]).inc();
     }
 }
 

--- a/crates/corrosion/src/gossip/metrics.rs
+++ b/crates/corrosion/src/gossip/metrics.rs
@@ -1,0 +1,572 @@
+use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec, opts};
+use std::time::Duration;
+
+#[derive(Copy, Clone)]
+pub enum Direction {
+    /// Data received from a remote peer
+    In,
+    /// Data sent to a remote peer
+    Out,
+}
+
+impl Direction {
+    #[inline]
+    fn to_str(self) -> &'static str {
+        match self {
+            Self::In => "in",
+            Self::Out => "out",
+        }
+    }
+}
+
+pub struct GossipMetrics {
+    total_conns: IntCounter,
+    active_conns: IntGauge,
+    failed_handshakes: IntCounterVec,
+    total_datagrams: IntCounter,
+    total_datagram_bytes: IntCounter,
+    failed_datagrams: IntCounterVec,
+    total_streams: IntCounterVec,
+    active_streams: IntGaugeVec,
+    total_stream_bytes: IntCounterVec,
+    failed_streams: IntCounterVec,
+
+    sync_changes: IntCounterVec,
+    sync_requests: IntCounterVec,
+
+    change_batches: IntCounterVec,
+    change_batch_size: IntGauge,
+    change_dropped: IntCounter,
+    change_received: IntCounter,
+    change_bx_duplicate: IntCounterVec,
+    change_clock: IntCounterVec,
+    change_bx_received: IntCounterVec,
+    change_recv_lag: prometheus::HistogramVec,
+    changes_in_queue: IntGauge,
+    changesets_in_queue: IntGauge,
+    changes_committed: IntCounterVec,
+    changes_processed_time: prometheus::HistogramVec,
+    changes_processed_chunk_size: prometheus::Histogram,
+    changes_queued_time: prometheus::Histogram,
+    channel_errors: IntCounterVec,
+
+    broadcast_dropped: IntCounter,
+    broadcast_remaining_burst: IntGauge,
+
+    client_datagram_errors: IntCounterVec,
+    client_datagrams: IntCounter,
+    client_datagram_bytes: IntCounter,
+}
+
+impl GossipMetrics {
+    pub fn new(registry: &'static prometheus::Registry) -> &'static Self {
+        static THIS: std::sync::OnceLock<GossipMetrics> = std::sync::OnceLock::new();
+
+        THIS.get_or_init(|| {
+            let active_conns = prometheus::register_int_gauge_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_active_connections",
+                    "Number of active server gossip connections",
+                },
+                registry,
+            }
+            .unwrap();
+            let total_conns = prometheus::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_total_connections",
+                    "Number of total server gossip connections",
+                },
+                registry,
+            }
+            .unwrap();
+            let failed_handshakes = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_failed_handshakes",
+                    "Number of total failed server gossip handshakes",
+                },
+                &["error_kind"],
+                registry,
+            }
+            .unwrap();
+            let total_datagrams = prometheus::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_total_datagrams",
+                    "Number of total incoming server gossip foca datagrams",
+                },
+                registry,
+            }
+            .unwrap();
+            let total_datagram_bytes = prometheus::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_total_datagram_bytes",
+                    "Number of total incoming server gossip foca datagram bytes",
+                },
+                registry,
+            }
+            .unwrap();
+            let failed_datagrams = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_failed_datagrams",
+                    "Number of total failed gossip foca datagrams",
+                },
+                &["error_kind"],
+                registry,
+            }
+            .unwrap();
+            let total_streams = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_total_streams",
+                    "Number of total incoming server gossip streams",
+                },
+                &["stream_kind"],
+                registry,
+            }
+            .unwrap();
+            let active_streams = prometheus::register_int_gauge_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_active_streams",
+                    "Number of total active server gossip streams",
+                },
+                &["stream_kind"],
+                registry,
+            }
+            .unwrap();
+            let total_stream_bytes = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_total_stream_bytes",
+                    "Number of total incoming server gossip foca datagram bytes",
+                },
+                &["stream_kind", "direction", "traffic"],
+                registry,
+            }
+            .unwrap();
+            let failed_streams = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_server_failed_streams",
+                    "Number of total failed server gossip streams",
+                },
+                &["error_kind", "stream_kind"],
+                registry,
+            }
+            .unwrap();
+            let sync_changes = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_sync_changes",
+                    "Number of total gossip sync changes",
+                },
+                &["direction"],
+                registry,
+            }
+            .unwrap();
+            let sync_requests = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_sync_requests",
+                    "Number of total gossip sync requests",
+                },
+                &["direction"],
+                registry,
+            }
+            .unwrap();
+            let change_batches = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_batches",
+                    "Number of total gossip change batches applied",
+                },
+                &["reason"],
+                registry,
+            }
+            .unwrap();
+            let change_batch_size = prometheus::register_int_gauge_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_batch_size",
+                    "Size of the change batch currently being processed",
+                },
+                registry,
+            }
+            .unwrap();
+            let change_dropped = prometheus::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_dropped",
+                    "Total number of changes that have been dropped due to overflowing the maximum change queue",
+                },
+                registry,
+            }
+            .unwrap();
+            let change_received = prometheus::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_received",
+                    "Total number of changes that have been received by the chang processor",
+                },
+                registry,
+            }
+            .unwrap();
+            let change_bx_duplicate = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_broadcast_duplicates",
+                    "Number of total duplicate gossip changes broadcast",
+                },
+                &["from"],
+                registry,
+            }
+            .unwrap();
+            let change_clock = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_clock",
+                    "Number of total gossip changes clock updates",
+                },
+                &["source"],
+                registry,
+            }
+            .unwrap();
+            let change_bx_received = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_broadcast_received",
+                    "Number of total gossip broadcast changes received",
+                },
+                &["kind"],
+                registry,
+            }
+            .unwrap();
+            let change_recv_lag = prometheus::register_histogram_vec_with_registry! {
+                prometheus::histogram_opts! {
+                    "corrosion_gossip_change_recv_lag",
+                    "Receive lag in seconds",
+                },
+                &["source"],
+                registry,
+            }.unwrap();
+            let changes_in_queue = prometheus::register_int_gauge_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_in_queue",
+                    "Number of changes in the queue",
+                },
+                registry,
+            }
+            .unwrap();
+            let changesets_in_queue = prometheus::register_int_gauge_with_registry! {
+                opts! {
+                    "corrosion_gossip_changesets_in_queue",
+                    "Number of change sets in the queue",
+                },
+                registry,
+            }
+            .unwrap();
+            let changes_committed = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_change_committed",
+                    "Number of total gossip changes committed",
+                },
+                &["table", "source"],
+                registry,
+            }
+            .unwrap();
+            let changes_processed_time = prometheus::register_histogram_vec_with_registry! {
+                prometheus::histogram_opts! {
+                    "corrosion_gossip_changes_processed_time",
+                    "Gossip changes processing time in seconds",
+                },
+                &["source"],
+                registry,
+            }.unwrap();
+            let changes_processed_chunk_size = prometheus::register_histogram_with_registry! {
+                prometheus::histogram_opts! {
+                    "corrosion_gossip_changes_processed_chunk_size",
+                    "Gossip changes processing chunk sizes",
+                },
+                registry,
+            }.unwrap();
+            let changes_queued_time = prometheus::register_histogram_with_registry! {
+                prometheus::histogram_opts! {
+                    "corrosion_gossip_changes_queued",
+                    "Gossip changes queued time",
+                },
+                registry,
+            }.unwrap();
+            let channel_errors = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_channel_errors",
+                    "Number of total gossip channel errors",
+                },
+                &["kind", "name"],
+                registry,
+            }
+            .unwrap();
+            let broadcast_dropped = prometheus::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_broadcast_dropped",
+                    "Total number of broadcasts that have been dropped due to overflowing the maximum broadcast queue",
+                },
+                registry,
+            }
+            .unwrap();
+            let broadcast_remaining_burst = prometheus::register_int_gauge_with_registry! {
+                opts! {
+                    "corrosion_gossip_broadcast_limiter_remaining_burst",
+                    "Remaining burst capacity of the broadcast limiter",
+                },
+                registry,
+            }
+            .unwrap();
+            let client_datagram_errors = prometheus::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_client_datagram_errors",
+                    "Number of total client datagram errors that have occurred",
+                },
+                &["error"],
+                registry,
+            }
+            .unwrap();
+            let client_datagrams = prometheus::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_client_total_datagrams",
+                    "Number of total outgoing client gossip foca datagrams",
+                },
+                registry,
+            }
+            .unwrap();
+            let client_datagram_bytes = prometheus::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_client_total_datagram_bytes",
+                    "Number of total outgoing client datagram bytes",
+                },
+                registry,
+            }
+            .unwrap();
+
+            Self {
+                active_conns,
+                total_conns,
+                failed_handshakes,
+                total_datagrams,
+                total_datagram_bytes,
+                failed_datagrams,
+                total_streams,
+                active_streams,
+                total_stream_bytes,
+                failed_streams,
+                sync_changes,
+                sync_requests,
+                change_batches,
+                change_batch_size,
+                change_dropped,
+                change_received,
+                change_bx_duplicate,
+                change_clock,
+                change_bx_received,
+                change_recv_lag,
+                changes_in_queue,
+                changesets_in_queue,
+                changes_committed,
+                changes_processed_time,
+                changes_processed_chunk_size,
+                changes_queued_time,
+                channel_errors,
+                broadcast_dropped,
+                broadcast_remaining_burst,
+                client_datagram_errors,
+client_datagrams,
+client_datagram_bytes,
+            }
+        })
+    }
+
+    #[inline]
+    pub fn server_conns_inc(&self) {
+        self.active_conns.inc();
+        self.total_conns.inc();
+    }
+
+    #[inline]
+    pub fn server_conns_dec(&self) {
+        self.active_conns.dec();
+    }
+
+    #[inline]
+    pub fn server_handshakes_failed_inc(&self, error: &quinn::ConnectionError) {
+        self.failed_handshakes
+            .with_label_values(&[connection_error_to_string(error)])
+            .inc();
+    }
+
+    #[inline]
+    pub fn server_datagrams_inc(&self, datagram: &bytes::Bytes) {
+        self.total_datagrams.inc();
+        self.total_datagram_bytes.inc_by(datagram.len() as _);
+    }
+
+    #[inline]
+    pub fn server_datagrams_failed_inc(&self, error: &quinn::ConnectionError) {
+        self.failed_datagrams
+            .with_label_values(&[connection_error_to_string(error)])
+            .inc();
+    }
+
+    #[inline]
+    pub fn server_streams_failed_inc(&self, error: &quinn::ConnectionError, kind: quinn::Dir) {
+        self.failed_streams
+            .with_label_values(&[connection_error_to_string(error), dir_to_string(kind)])
+            .inc();
+    }
+
+    #[inline]
+    pub fn server_streams_inc(&self, dir: quinn::Dir) {
+        let dir = dir_to_string(dir);
+        self.total_streams.with_label_values(&[dir]).inc();
+        self.active_streams.with_label_values(&[dir]).inc();
+    }
+
+    #[inline]
+    pub fn sever_streams_dec(&self, dir: quinn::Dir) {
+        self.active_streams
+            .with_label_values(&[dir_to_string(dir)])
+            .dec();
+    }
+
+    #[inline]
+    pub fn server_stream_bytes_inc(
+        &self,
+        len: u64,
+        stream_kind: quinn::Dir,
+        dir: Direction,
+        traffic: &'static str,
+    ) {
+        self.total_stream_bytes
+            .with_label_values(&[dir_to_string(stream_kind), dir.to_str(), traffic])
+            .inc_by(len);
+    }
+
+    #[inline]
+    pub fn sync_changes_inc(&self, len: u64, dir: Direction) {
+        self.sync_changes
+            .with_label_values(&[dir.to_str()])
+            .inc_by(len);
+    }
+
+    #[inline]
+    pub fn sync_requests_inc(&self, len: u64, dir: Direction) {
+        self.sync_requests
+            .with_label_values(&[dir.to_str()])
+            .inc_by(len);
+    }
+
+    #[inline]
+    pub fn change_batches_inc(&self, reason: &'static str) {
+        self.change_batches.with_label_values(&[reason]).inc();
+    }
+
+    #[inline]
+    pub fn change_batch_size(&self, size: usize) {
+        self.change_batch_size.set(size as _);
+    }
+
+    #[inline]
+    pub fn change_received_inc(&self, size: usize) {
+        self.change_received.inc_by(size as _);
+    }
+
+    #[inline]
+    pub fn change_dropped_inc(&self) {
+        self.change_dropped.inc();
+    }
+
+    #[inline]
+    pub fn change_broadcast_duplicate_inc(&self, from: &'static str) {
+        self.change_bx_duplicate.with_label_values(&[from]).inc();
+    }
+
+    #[inline]
+    pub fn change_clock_inc(&self, src: &'static str) {
+        self.change_clock.with_label_values(&[src]).inc();
+    }
+
+    #[inline]
+    pub fn change_broadcast_received_inc(&self, kind: &'static str) {
+        self.change_bx_received.with_label_values(&[kind]).inc();
+    }
+
+    #[inline]
+    pub fn change_recv_lag_sample(&self, lag: f64, src: &'static str) {
+        self.change_recv_lag.with_label_values(&[src]).observe(lag);
+    }
+
+    #[inline]
+    pub fn changes_queued(&self, cost: usize, changesets: usize) {
+        self.changes_in_queue.set(cost as _);
+        self.changesets_in_queue.set(changesets as _);
+    }
+
+    #[inline]
+    pub fn changes_committed_inc(&self, table: &str, count: u64, source: &'static str) {
+        self.changes_committed
+            .with_label_values(&[table, source])
+            .inc_by(count);
+    }
+
+    #[inline]
+    pub fn changes_processed(&self, elapsed: Duration, source: &'static str, count: Option<usize>) {
+        self.changes_processed_time
+            .with_label_values(&[source])
+            .observe(elapsed.as_secs_f64());
+        if let Some(count) = count {
+            self.changes_processed_chunk_size.observe(count as _);
+        }
+    }
+
+    #[inline]
+    pub fn changes_queued_time(&self, elapsed: Duration) {
+        self.changes_queued_time.observe(elapsed.as_secs_f64());
+    }
+
+    #[inline]
+    pub fn channel_error_inc(&self, kind: &'static str, name: &'static str) {
+        self.channel_errors.with_label_values(&[kind, name]).inc();
+    }
+
+    #[inline]
+    pub fn broadcast_dropped_inc(&self) {
+        self.broadcast_dropped.inc();
+    }
+
+    #[inline]
+    pub fn broadcast_remaining_burst(&self, remaining: u32) {
+        self.broadcast_remaining_burst.set(remaining as _);
+    }
+
+    #[inline]
+    pub fn client_datagram_errors_inc(&self, error: &'static str) {
+        self.client_datagram_errors
+            .with_label_values(&[error])
+            .inc();
+    }
+
+    #[inline]
+    pub fn client_datagrams_sent_inc(&self, len: usize) {
+        self.client_datagrams.inc();
+        self.client_datagram_bytes.inc_by(len as _);
+    }
+}
+
+#[inline]
+fn dir_to_string(dir: quinn::Dir) -> &'static str {
+    match dir {
+        quinn::Dir::Uni => "uni",
+        quinn::Dir::Bi => "bi",
+    }
+}
+
+#[inline]
+fn connection_error_to_string(error: &quinn::ConnectionError) -> &'static str {
+    #[allow(clippy::enum_glob_use)]
+    use quinn::ConnectionError::*;
+
+    match error {
+        VersionMismatch => "version_mismatch",
+        TransportError(_) => "transport_error",
+        ConnectionClosed(_) => "connection_closed",
+        ApplicationClosed(_) => "application_closed",
+        Reset => "reset",
+        TimedOut => "timed_out",
+        LocallyClosed => "locally_closed",
+        CidsExhausted => "cids_exhausted",
+    }
+}

--- a/crates/corrosion/src/gossip/metrics.rs
+++ b/crates/corrosion/src/gossip/metrics.rs
@@ -1,5 +1,9 @@
-use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec, opts};
+use prometheus::{
+    self as p, Histogram, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, opts,
+};
 use std::time::Duration;
+
+use crate::gossip::transport::TrafficClass;
 
 #[derive(Copy, Clone)]
 pub enum Direction {
@@ -41,29 +45,33 @@ pub struct GossipMetrics {
     change_bx_duplicate: IntCounterVec,
     change_clock: IntCounterVec,
     change_bx_received: IntCounterVec,
-    change_recv_lag: prometheus::HistogramVec,
+    change_recv_lag: HistogramVec,
     changes_in_queue: IntGauge,
     changesets_in_queue: IntGauge,
     changes_committed: IntCounterVec,
-    changes_processed_time: prometheus::HistogramVec,
-    changes_processed_chunk_size: prometheus::Histogram,
-    changes_queued_time: prometheus::Histogram,
+    changes_processed_time: HistogramVec,
+    changes_processed_chunk_size: Histogram,
+    changes_queued_time: Histogram,
     channel_errors: IntCounterVec,
 
     broadcast_dropped: IntCounter,
     broadcast_remaining_burst: IntGauge,
+    broadcast_rate_limited: IntCounter,
+    broadcast_spawned: IntCounterVec,
 
     client_datagram_errors: IntCounterVec,
-    client_datagrams: IntCounter,
-    client_datagram_bytes: IntCounter,
+    client_chunks_sent: IntCounterVec,
+    client_bytes_sent: IntCounterVec,
+    client_connect_time: HistogramVec,
+    client_connect_errors: IntCounterVec,
 }
 
 impl GossipMetrics {
-    pub fn new(registry: &'static prometheus::Registry) -> &'static Self {
+    pub fn new(registry: &'static p::Registry) -> &'static Self {
         static THIS: std::sync::OnceLock<GossipMetrics> = std::sync::OnceLock::new();
 
         THIS.get_or_init(|| {
-            let active_conns = prometheus::register_int_gauge_with_registry! {
+            let active_conns = p::register_int_gauge_with_registry! {
                 opts! {
                     "corrosion_gossip_server_active_connections",
                     "Number of active server gossip connections",
@@ -71,7 +79,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let total_conns = prometheus::register_int_counter_with_registry! {
+            let total_conns = p::register_int_counter_with_registry! {
                 opts! {
                     "corrosion_gossip_server_total_connections",
                     "Number of total server gossip connections",
@@ -79,7 +87,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let failed_handshakes = prometheus::register_int_counter_vec_with_registry! {
+            let failed_handshakes = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_server_failed_handshakes",
                     "Number of total failed server gossip handshakes",
@@ -88,7 +96,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let total_datagrams = prometheus::register_int_counter_with_registry! {
+            let total_datagrams = p::register_int_counter_with_registry! {
                 opts! {
                     "corrosion_gossip_server_total_datagrams",
                     "Number of total incoming server gossip foca datagrams",
@@ -104,7 +112,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let failed_datagrams = prometheus::register_int_counter_vec_with_registry! {
+            let failed_datagrams = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_failed_datagrams",
                     "Number of total failed gossip foca datagrams",
@@ -122,7 +130,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let active_streams = prometheus::register_int_gauge_vec_with_registry! {
+            let active_streams = p::register_int_gauge_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_server_active_streams",
                     "Number of total active server gossip streams",
@@ -131,7 +139,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let total_stream_bytes = prometheus::register_int_counter_vec_with_registry! {
+            let total_stream_bytes = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_server_total_stream_bytes",
                     "Number of total incoming server gossip foca datagram bytes",
@@ -140,7 +148,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let failed_streams = prometheus::register_int_counter_vec_with_registry! {
+            let failed_streams = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_server_failed_streams",
                     "Number of total failed server gossip streams",
@@ -149,7 +157,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let sync_changes = prometheus::register_int_counter_vec_with_registry! {
+            let sync_changes = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_sync_changes",
                     "Number of total gossip sync changes",
@@ -158,7 +166,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let sync_requests = prometheus::register_int_counter_vec_with_registry! {
+            let sync_requests = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_sync_requests",
                     "Number of total gossip sync requests",
@@ -167,7 +175,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let change_batches = prometheus::register_int_counter_vec_with_registry! {
+            let change_batches = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_change_batches",
                     "Number of total gossip change batches applied",
@@ -176,7 +184,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let change_batch_size = prometheus::register_int_gauge_with_registry! {
+            let change_batch_size = p::register_int_gauge_with_registry! {
                 opts! {
                     "corrosion_gossip_change_batch_size",
                     "Size of the change batch currently being processed",
@@ -184,7 +192,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let change_dropped = prometheus::register_int_counter_with_registry! {
+            let change_dropped = p::register_int_counter_with_registry! {
                 opts! {
                     "corrosion_gossip_change_dropped",
                     "Total number of changes that have been dropped due to overflowing the maximum change queue",
@@ -192,7 +200,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let change_received = prometheus::register_int_counter_with_registry! {
+            let change_received = p::register_int_counter_with_registry! {
                 opts! {
                     "corrosion_gossip_change_received",
                     "Total number of changes that have been received by the chang processor",
@@ -200,7 +208,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let change_bx_duplicate = prometheus::register_int_counter_vec_with_registry! {
+            let change_bx_duplicate = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_change_broadcast_duplicates",
                     "Number of total duplicate gossip changes broadcast",
@@ -209,7 +217,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let change_clock = prometheus::register_int_counter_vec_with_registry! {
+            let change_clock = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_change_clock",
                     "Number of total gossip changes clock updates",
@@ -218,7 +226,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let change_bx_received = prometheus::register_int_counter_vec_with_registry! {
+            let change_bx_received = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_change_broadcast_received",
                     "Number of total gossip broadcast changes received",
@@ -227,15 +235,15 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let change_recv_lag = prometheus::register_histogram_vec_with_registry! {
-                prometheus::histogram_opts! {
+            let change_recv_lag = p::register_histogram_vec_with_registry! {
+                p::histogram_opts! {
                     "corrosion_gossip_change_recv_lag",
                     "Receive lag in seconds",
                 },
                 &["source"],
                 registry,
             }.unwrap();
-            let changes_in_queue = prometheus::register_int_gauge_with_registry! {
+            let changes_in_queue = p::register_int_gauge_with_registry! {
                 opts! {
                     "corrosion_gossip_change_in_queue",
                     "Number of changes in the queue",
@@ -243,7 +251,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let changesets_in_queue = prometheus::register_int_gauge_with_registry! {
+            let changesets_in_queue = p::register_int_gauge_with_registry! {
                 opts! {
                     "corrosion_gossip_changesets_in_queue",
                     "Number of change sets in the queue",
@@ -251,7 +259,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let changes_committed = prometheus::register_int_counter_vec_with_registry! {
+            let changes_committed = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_change_committed",
                     "Number of total gossip changes committed",
@@ -260,29 +268,29 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let changes_processed_time = prometheus::register_histogram_vec_with_registry! {
-                prometheus::histogram_opts! {
+            let changes_processed_time = p::register_histogram_vec_with_registry! {
+                p::histogram_opts! {
                     "corrosion_gossip_changes_processed_time",
                     "Gossip changes processing time in seconds",
                 },
                 &["source"],
                 registry,
             }.unwrap();
-            let changes_processed_chunk_size = prometheus::register_histogram_with_registry! {
-                prometheus::histogram_opts! {
+            let changes_processed_chunk_size = p::register_histogram_with_registry! {
+                p::histogram_opts! {
                     "corrosion_gossip_changes_processed_chunk_size",
                     "Gossip changes processing chunk sizes",
                 },
                 registry,
             }.unwrap();
-            let changes_queued_time = prometheus::register_histogram_with_registry! {
-                prometheus::histogram_opts! {
+            let changes_queued_time = p::register_histogram_with_registry! {
+                p::histogram_opts! {
                     "corrosion_gossip_changes_queued",
                     "Gossip changes queued time",
                 },
                 registry,
             }.unwrap();
-            let channel_errors = prometheus::register_int_counter_vec_with_registry! {
+            let channel_errors = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_channel_errors",
                     "Number of total gossip channel errors",
@@ -291,7 +299,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let broadcast_dropped = prometheus::register_int_counter_with_registry! {
+            let broadcast_dropped = p::register_int_counter_with_registry! {
                 opts! {
                     "corrosion_gossip_broadcast_dropped",
                     "Total number of broadcasts that have been dropped due to overflowing the maximum broadcast queue",
@@ -299,7 +307,7 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let broadcast_remaining_burst = prometheus::register_int_gauge_with_registry! {
+            let broadcast_remaining_burst = p::register_int_gauge_with_registry! {
                 opts! {
                     "corrosion_gossip_broadcast_limiter_remaining_burst",
                     "Remaining burst capacity of the broadcast limiter",
@@ -307,7 +315,24 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let client_datagram_errors = prometheus::register_int_counter_vec_with_registry! {
+            let broadcast_rate_limited = p::register_int_counter_with_registry! {
+                opts! {
+                    "corrosion_gossip_broadcast_rate_limited",
+                    "Total number of times that broadcasting has been rate limited",
+                },
+                registry,
+            }
+            .unwrap();
+            let broadcast_spawned = p::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_broadcast_spawned",
+                    "Total number of broadcast tasks that have been spawned",
+                },
+                &["kind"],
+                registry,
+            }
+            .unwrap();
+            let client_datagram_errors = p::register_int_counter_vec_with_registry! {
                 opts! {
                     "corrosion_gossip_client_datagram_errors",
                     "Number of total client datagram errors that have occurred",
@@ -316,19 +341,38 @@ impl GossipMetrics {
                 registry,
             }
             .unwrap();
-            let client_datagrams = prometheus::register_int_counter_with_registry! {
+            let client_chunks_sent = p::register_int_counter_vec_with_registry! {
                 opts! {
-                    "corrosion_gossip_client_total_datagrams",
-                    "Number of total outgoing client gossip foca datagrams",
+                    "corrosion_gossip_client_total_chunks",
+                    "Number of total outgoing client gossip data chunks",
                 },
+                &["traffic"],
                 registry,
             }
             .unwrap();
-            let client_datagram_bytes = prometheus::register_int_counter_with_registry! {
+            let client_bytes_sent = p::register_int_counter_vec_with_registry! {
                 opts! {
-                    "corrosion_gossip_client_total_datagram_bytes",
-                    "Number of total outgoing client datagram bytes",
+                    "corrosion_gossip_client_total_bytes_sent",
+                    "Number of total outgoing client bytes",
                 },
+                &["traffic"],
+                registry,
+            }
+            .unwrap();
+            let client_connect_time = p::register_histogram_vec_with_registry! {
+                prometheus::histogram_opts! {
+                    "corrosion_gossip_client_connect_time",
+                    "Gossip client connection time in seconds",
+                },
+                &["traffic"],
+                registry,
+            }.unwrap();
+            let client_connect_errors = p::register_int_counter_vec_with_registry! {
+                opts! {
+                    "corrosion_gossip_client_connect_errors",
+                    "Number of total gossip client connection errors",
+                },
+                &["traffic", "error"],
                 registry,
             }
             .unwrap();
@@ -363,9 +407,13 @@ impl GossipMetrics {
                 channel_errors,
                 broadcast_dropped,
                 broadcast_remaining_burst,
+                broadcast_rate_limited,
+                broadcast_spawned,
                 client_datagram_errors,
-client_datagrams,
-client_datagram_bytes,
+                client_chunks_sent,
+                client_bytes_sent,
+                client_connect_time,
+                client_connect_errors,
             }
         })
     }
@@ -416,22 +464,22 @@ client_datagram_bytes,
     }
 
     #[inline]
-    pub fn sever_streams_dec(&self, dir: quinn::Dir) {
+    pub fn server_streams_dec(&self, dir: quinn::Dir) {
         self.active_streams
             .with_label_values(&[dir_to_string(dir)])
             .dec();
     }
 
     #[inline]
-    pub fn server_stream_bytes_inc(
+    pub fn stream_bytes_inc(
         &self,
         len: u64,
         stream_kind: quinn::Dir,
         dir: Direction,
-        traffic: &'static str,
+        traffic: TrafficClass,
     ) {
         self.total_stream_bytes
-            .with_label_values(&[dir_to_string(stream_kind), dir.to_str(), traffic])
+            .with_label_values(&[dir_to_string(stream_kind), dir.to_str(), traffic.as_str()])
             .inc_by(len);
     }
 
@@ -533,6 +581,32 @@ client_datagram_bytes,
     }
 
     #[inline]
+    pub fn broadcast_rate_limited_inc(&self) {
+        self.broadcast_rate_limited.inc();
+    }
+
+    #[inline]
+    pub fn broadcast_spawned_inc(&self, kind: &'static str, count: u32) {
+        self.broadcast_spawned
+            .with_label_values(&[kind])
+            .inc_by(count as _);
+    }
+
+    #[inline]
+    pub fn client_connect_time(&self, elapsed: Duration, traffic: TrafficClass) {
+        self.client_connect_time
+            .with_label_values(&[traffic.as_str()])
+            .observe(elapsed.as_secs_f64());
+    }
+
+    #[inline]
+    pub fn client_connect_error(&self, traffic: TrafficClass, error: &'static str) {
+        self.client_connect_errors
+            .with_label_values(&[traffic.as_str(), error])
+            .inc();
+    }
+
+    #[inline]
     pub fn client_datagram_errors_inc(&self, error: &'static str) {
         self.client_datagram_errors
             .with_label_values(&[error])
@@ -540,9 +614,13 @@ client_datagram_bytes,
     }
 
     #[inline]
-    pub fn client_datagrams_sent_inc(&self, len: usize) {
-        self.client_datagrams.inc();
-        self.client_datagram_bytes.inc_by(len as _);
+    pub fn client_chunks_sent_inc(&self, len: usize, traffic: TrafficClass) {
+        let ts = traffic.as_str();
+
+        self.client_chunks_sent.with_label_values(&[ts]).inc();
+        self.client_bytes_sent
+            .with_label_values(&[ts])
+            .inc_by(len as _);
     }
 }
 

--- a/crates/corrosion/src/gossip/swim.rs
+++ b/crates/corrosion/src/gossip/swim.rs
@@ -1,4 +1,4 @@
-use super::GossipMetrics;
+use super::{GossipMetrics, transport::Transport};
 use bytes::{Bytes, BytesMut};
 use corro_types::{
     actor::{self, Actor},
@@ -8,7 +8,7 @@ use corro_types::{
 };
 use foca::{Identity, Timer};
 use parking_lot::RwLock;
-use rand::{SeedableRng, rngs::StdRng};
+use rand::{SeedableRng, rngs::StdRng, seq::IteratorRandom};
 use std::{
     collections::VecDeque,
     net::SocketAddr,
@@ -16,7 +16,6 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::sync::mpsc;
-use transport::Transport;
 use tripwire::PreemptibleFutureExt;
 
 type Foca = foca::Foca<
@@ -88,6 +87,7 @@ pub struct SwimCtx {
 }
 
 /// Entry point for the SWIM-based gossip
+#[allow(clippy::too_many_arguments)]
 pub fn swim_loop(
     ctx: SwimCtx,
     actor: Actor,
@@ -97,7 +97,7 @@ pub fn swim_loop(
     to_send: mpsc::Sender<(Actor, Bytes)>,
     notifications_tx: mpsc::Sender<foca::OwnedNotification<Actor>>,
     tripwire: tripwire::Tripwire,
-    mut member_states: Vec<(std::net::SocketAddr, foca::Member<Actor>)>,
+    member_states: Vec<(std::net::SocketAddr, foca::Member<Actor>)>,
 ) {
     let rng = StdRng::from_os_rng();
 
@@ -144,8 +144,8 @@ pub fn swim_loop(
     // NOTE: every turn of that loop should be fast or else we risk being a down suspect
     spawn::spawn_counted({
         let config = config.clone();
-        let agent = agent.clone();
         let cluster_size = cluster_size.clone();
+        let ctx = ctx.clone();
         let mut tripwire = tripwire.clone();
 
         async move {
@@ -332,10 +332,10 @@ pub fn swim_loop(
                     },
                     input = foca_rx.recv(), if !foca_done => match input {
                         Some(FocaInput::Data(data)) => {
-                            _ = foca.handle_data(&data, &mut runtime);
+                            drop(foca.handle_data(&data, &mut runtime));
                         },
                         None => {
-                            foca_done = true
+                            foca_done = true;
                         }
                         _ => {
 
@@ -412,7 +412,8 @@ impl TimerSpawner {
                     // spawned tasks have returned.
                     rt.block_on(local);
                 }
-            });
+            })
+            .expect("failed to spawn foca runtime timer thread");
 
         Self { send }
     }
@@ -440,7 +441,7 @@ fn handle_timer(
     }
 
     // sort by instant these were scheduled
-    v.sort_by(|a, b| a.1.cmp(&b.1));
+    v.sort_by_key(|a| a.1);
 
     for (timer, _) in v {
         let Err(error) = foca.handle_timer(timer, &mut *runtime) else {
@@ -641,6 +642,8 @@ fn diff_member_states(
 struct PendingBroadcast {
     payload: Bytes,
     is_local: bool,
+    /// Corrosion was using a `HashSet` for this, I don't really see this being more than several relays ever at a time so
+    /// a Vec will be cheaper in all cases
     sent_to: Vec<SocketAddr>,
     send_count: u8,
 }
@@ -661,6 +664,18 @@ impl PendingBroadcast {
             is_local: true,
             sent_to: Default::default(),
             send_count: 0,
+        }
+    }
+
+    #[inline]
+    pub fn contains(&self, addr: &SocketAddr) -> bool {
+        self.sent_to.iter().any(|s| s == addr)
+    }
+
+    #[inline]
+    pub fn insert(&mut self, addr: SocketAddr) {
+        if !self.contains(&addr) {
+            self.sent_to.push(addr);
         }
     }
 }
@@ -717,14 +732,12 @@ async fn handle_broadcasts(
     let mut tripped = false;
     let mut ser_buf = BytesMut::new();
 
-    let mut join_set = tokio::task::JoinSet::new();
-    let max_queue_len = agent.config().perf.processing_queue_len;
     const MAX_INFLIGHT_BROADCAST: usize = 500;
+    const MAX_QUEUE_LEN: usize = 20_000;
+
+    let mut join_set = tokio::task::JoinSet::new();
     let mut to_broadcast = VecDeque::new();
     let mut to_local_broadcast = VecDeque::new();
-    let mut log_count = 0;
-
-    let mut limited_log_count = 0;
 
     let bytes_per_sec = governor::RateLimiter::direct(governor::Quota::per_second(
         std::num::NonZeroU32::new(10 * 1024 * 1024).unwrap(),
@@ -846,7 +859,7 @@ async fn handle_broadcasts(
         let prev_rate_limited = std::mem::take(&mut rate_limited);
 
         // start with local broadcasts, they're higher priority
-        let mut ring0 = HashSet::new();
+        let mut ring0 = std::collections::HashSet::new();
         while !to_local_broadcast.is_empty() && join_set.len() < MAX_INFLIGHT_BROADCAST {
             // UNWRAP: we just checked that it wasn't empty
             let payload = to_local_broadcast.pop_front().unwrap();
@@ -870,18 +883,18 @@ async fn handle_broadcasts(
                     payload.clone(),
                     transport.clone(),
                     addr,
+                    ctx.metrics,
                 ) {
-                    Err(e) => {
-                        match e {
+                    Err(error) => {
+                        match error {
                             TransmitError::TooBig(_) | TransmitError::InsufficientCapacity(_) => {
                                 // not sure this would ever happen
-                                error!("could not spawn broadcast transmission: {e}");
-                                continue;
+                                tracing::error!(%error, "could not spawn broadcast transmission");
                             }
                             TransmitError::QuotaExceeded(_) => {
                                 // exceeded our quota, stop trying to send this through
                                 rate_limited = true;
-                                counter!("corro.broadcast.rate_limited").increment(1);
+                                ctx.metrics.broadcast_rate_limited_inc();
                                 break;
                             }
                         }
@@ -901,14 +914,14 @@ async fn handle_broadcasts(
                 break;
             }
 
-            counter!("corro.broadcast.spawn", "type" => "local").increment(spawn_count);
+            ctx.metrics.broadcast_spawned_inc("local", spawn_count);
         }
 
         if !rate_limited && !to_broadcast.is_empty() && join_set.len() < MAX_INFLIGHT_BROADCAST {
             let (members_count, ring0_count) = {
-                let members = agent.members().read();
+                let members = ctx.members.read();
                 let members_count = members.states.len();
-                let ring0_count = members.ring0(agent.cluster_id()).count();
+                let ring0_count = members.ring0(ctx.cluster_id).count();
                 (members_count, ring0_count)
             };
 
@@ -917,11 +930,11 @@ async fn handle_broadcasts(
                 let max_transmissions = config.max_transmissions.get();
                 let dynamic_count =
                     (members_count - ring0_count) / (max_transmissions as usize * 10);
-                let count = cmp::max(config.num_indirect_probes.get(), dynamic_count);
+                let count = config.num_indirect_probes.get().max(dynamic_count);
 
                 if prev_rate_limited {
                     // we've been rate limited on the last loop, try sending to less nodes...
-                    (cmp::min(count, dynamic_count / 2), max_transmissions / 2)
+                    (count.min(dynamic_count / 2), max_transmissions / 2)
                 } else {
                     (count, max_transmissions)
                 }
@@ -931,8 +944,7 @@ async fn handle_broadcasts(
                 let mut pending = to_broadcast.pop_front().unwrap();
 
                 let broadcast_to = {
-                    agent
-                        .members()
+                    ctx.members
                         .read()
                         .states
                         .iter()
@@ -941,10 +953,10 @@ async fn handle_broadcasts(
                             // (ring0 could have changed since the time we sent the local broadcast
                             // so we check the ring0 variable that's created at start of local_broacast
                             // instead of state.is_ring0())
-                            if *member_id == actor_id
-                                || state.cluster_id != agent.cluster_id()
+                            if *member_id == ctx.actor_id
+                                || state.cluster_id != ctx.cluster_id
                                 || (pending.is_local && ring0.contains(&state.addr))
-                                || pending.sent_to.contains(&state.addr)
+                                || pending.contains(&state.addr)
                             // don't broadcast to this peer
                             {
                                 None
@@ -955,74 +967,67 @@ async fn handle_broadcasts(
                         .choose_multiple(
                             &mut rng,
                             // prevent going over max count
-                            cmp::min(
-                                choose_count,
-                                MAX_INFLIGHT_BROADCAST.saturating_sub(join_set.len()),
-                            ),
+                            choose_count.min(MAX_INFLIGHT_BROADCAST.saturating_sub(join_set.len())),
                         )
                 };
 
                 let mut spawn_count = 0;
-                trace!("broadcasting to: {:?}", broadcast_to);
+
                 for addr in broadcast_to {
                     match try_transmit_broadcast(
                         &bytes_per_sec,
                         pending.payload.clone(),
                         transport.clone(),
                         addr,
+                        ctx.metrics,
                     ) {
-                        Err(e) => {
-                            warn!("could not spawn broadcast transmission: {e}");
-                            match e {
+                        Err(error) => {
+                            tracing::warn!(%error, "could not spawn broadcast transmission");
+
+                            match error {
                                 TransmitError::TooBig(_)
                                 | TransmitError::InsufficientCapacity(_) => {
                                     // not sure this would ever happen
-                                    continue;
                                 }
                                 TransmitError::QuotaExceeded(_) => {
                                     // exceeded our quota, stop trying to send this through
-                                    counter!("corro.broadcast.rate_limited").increment(1);
-                                    log_at_pow_10(
-                                        "broadcasts rate limited",
-                                        &mut limited_log_count,
-                                    );
+                                    ctx.metrics.broadcast_rate_limited_inc();
                                     break;
                                 }
                             }
                         }
                         Ok(fut) => {
-                            debug!(actor = %actor_id, "broadcasting {} bytes to: {addr}", pending.payload.len());
                             join_set.spawn(fut);
-                            pending.sent_to.insert(addr);
+                            pending.insert(addr);
                             spawn_count += 1;
                         }
                     }
                 }
 
-                counter!("corro.broadcast.spawn", "type" => "global").increment(spawn_count);
+                ctx.metrics.broadcast_spawned_inc("global", spawn_count);
 
-                if let Some(send_count) = pending.send_count.checked_add(1) {
-                    trace!("send_count: {send_count}, max_transmissions: {max_transmissions}");
-                    pending.send_count = send_count;
+                let Some(send_count) = pending.send_count.checked_add(1) else {
+                    continue;
+                };
 
-                    if send_count < max_transmissions {
-                        debug!("queueing for re-send");
-                        idle_pendings.push(Box::pin(async move {
-                            // slow our send pace if we've been previously rate limited
-                            let sleep_ms_base = if prev_rate_limited { 500 } else { 100 };
-                            // send with increasing latency as we've already sent the updates out
-                            tokio::time::sleep(Duration::from_millis(
-                                sleep_ms_base * send_count as u64,
-                            ))
-                            .await;
-                            pending
-                        }));
-                    }
+                pending.send_count = send_count;
+
+                if send_count >= max_transmissions {
+                    continue;
                 }
+
+                idle_pendings.push(Box::pin(async move {
+                    // slow our send pace if we've been previously rate limited
+                    let sleep_ms_base = if prev_rate_limited { 500 } else { 100 };
+                    // send with increasing latency as we've already sent the updates out
+                    tokio::time::sleep(Duration::from_millis(sleep_ms_base * send_count as u64))
+                        .await;
+                    pending
+                }));
             }
         }
 
-        if drop_oldest_broadcast(&mut to_broadcast, &mut to_local_broadcast, max_queue_len)
+        if drop_oldest_broadcast(&mut to_broadcast, &mut to_local_broadcast, MAX_QUEUE_LEN)
             .is_some()
         {
             ctx.metrics.broadcast_dropped_inc();
@@ -1082,7 +1087,7 @@ fn try_transmit_broadcast(
                     len as _,
                     quinn::Dir::Uni,
                     super::metrics::Direction::Out,
-                    "broadcast",
+                    super::transport::TrafficClass::Broadcast,
                 );
             }
         }

--- a/crates/corrosion/src/gossip/swim.rs
+++ b/crates/corrosion/src/gossip/swim.rs
@@ -3,7 +3,6 @@ use bytes::{Bytes, BytesMut};
 use corro_types::{
     actor::{self, Actor},
     broadcast::{self as bx, FocaCmd, FocaInput},
-    members,
     sqlite::unnest_param,
 };
 use foca::{Identity, Timer};
@@ -79,7 +78,7 @@ impl foca::Runtime<Actor> for DispatchRuntime {
 #[derive(Clone)]
 pub struct SwimCtx {
     pub pool: corro_types::agent::SplitPool,
-    pub members: Arc<parking_lot::RwLock<members::Members>>,
+    pub members: super::Members,
     pub actor_id: actor::ActorId,
     pub member_id: Option<actor::MemberId>,
     pub cluster_id: actor::ClusterId,
@@ -474,7 +473,7 @@ fn diff_member_states(
     }
 
     let (to_delete, to_update, foca_notifications) = {
-        let members = ctx.members.read();
+        let members = ctx.members.0.read();
 
         let to_update = foca_states
             .iter()
@@ -864,7 +863,7 @@ async fn handle_broadcasts(
             // UNWRAP: we just checked that it wasn't empty
             let payload = to_local_broadcast.pop_front().unwrap();
 
-            let members = ctx.members.read();
+            let members = ctx.members.0.read();
             let mut spawn_count = 0;
             let mut ring0_count = 0;
             for addr in members.ring0(ctx.cluster_id) {
@@ -919,7 +918,7 @@ async fn handle_broadcasts(
 
         if !rate_limited && !to_broadcast.is_empty() && join_set.len() < MAX_INFLIGHT_BROADCAST {
             let (members_count, ring0_count) = {
-                let members = ctx.members.read();
+                let members = ctx.members.0.read();
                 let members_count = members.states.len();
                 let ring0_count = members.ring0(ctx.cluster_id).count();
                 (members_count, ring0_count)
@@ -945,6 +944,7 @@ async fn handle_broadcasts(
 
                 let broadcast_to = {
                     ctx.members
+                        .0
                         .read()
                         .states
                         .iter()
@@ -1114,6 +1114,143 @@ fn drop_oldest_broadcast(
     } else {
         local_queue.pop_back().map(PendingBroadcast::new_local)
     }
+}
+
+/// A central dispatcher for SWIM cluster management messages
+///
+/// TODO: This is just a copy of what corrosion does, but IMO should probably just be in the main loop
+pub fn spawn_sender(
+    transport: Transport,
+    mut to_send_rx: mpsc::Receiver<(Actor, Bytes)>,
+    mut tripwire: tripwire::Tripwire,
+) {
+    spawn::spawn_counted(async move {
+        while let tripwire::Outcome::Completed(Some((actor, data))) =
+            to_send_rx.recv().preemptible(&mut tripwire).await
+        {
+            let Err(error) = transport.send_datagram(actor.addr(), data).await else {
+                continue;
+            };
+
+            tracing::error!(%error, address = %actor.addr(), "could not write datagram");
+        }
+
+        if tripwire.is_shutting_down() {
+            // Drain the queue
+            let mut total = 0;
+            let mut errors = 0;
+
+            let start = Instant::now();
+
+            while let Ok((actor, data)) = to_send_rx.try_recv() {
+                let res = transport.send_datagram(actor.addr(), data).await;
+
+                total += 1;
+                errors += if res.is_err() { 1 } else { 0 };
+            }
+
+            tracing::debug!(elapsed = ?start.elapsed(), total, errors, "drained SWIM datagrams before shutting down");
+        }
+    });
+}
+
+/// Poll for updates from the cluster membership system (`foca`/ SWIM) and apply any incoming changes to the local
+/// actor/agent state.
+pub fn spawn_notification_handler(
+    metrics: &'static GossipMetrics,
+    members: super::Members,
+    mut notification_rx: mpsc::Receiver<foca::OwnedNotification<Actor>>,
+    foca_tx: mpsc::Sender<FocaInput>,
+    mut tripwire: tripwire::Tripwire,
+) {
+    use corro_types::members::MemberAddedResult;
+    use foca::OwnedNotification as ON;
+
+    spawn::spawn_counted(async move {
+        while let tripwire::Outcome::Completed(Some(notification)) =
+            notification_rx.recv().preemptible(&mut tripwire).await
+        {
+            let kind = match notification {
+                ON::MemberUp(actor) => {
+                    let res = members.0.write().add_member(&actor);
+                    tracing::info!(?actor, member_added_result = ?res, "Member Up");
+
+                    match res {
+                        MemberAddedResult::NewMember | MemberAddedResult::Removed => {
+                            if matches!(res, MemberAddedResult::Removed) {
+                                metrics.member_removed_inc("member_id_mismatch");
+                            } else {
+                                metrics.member_added_inc();
+                            }
+
+                            let members_len = { members.0.read().states.len() as u32 };
+
+                            // actually added a member
+                            // notify of new cluster size
+                            if let Ok(size) = members_len.try_into()
+                                && let Err(error) = foca_tx.send(FocaInput::ClusterSize(size)).await
+                            {
+                                tracing::error!(%error, "could not send new foca cluster size");
+                            }
+                        }
+                        MemberAddedResult::Updated => {
+                            // anything else to do here?
+                        }
+                        MemberAddedResult::Ignored => {}
+                    }
+
+                    "memberup"
+                }
+                ON::MemberDown(actor) => {
+                    let removed = { members.0.write().remove_member(&actor) };
+                    tracing::info!(?actor, removed, "Member Down");
+
+                    if removed {
+                        metrics.member_removed_inc("member_down");
+
+                        // actually removed a member
+                        // notify of new cluster size
+                        let member_len = { members.0.read().states.len() as u32 };
+                        if let Ok(size) = member_len.try_into()
+                            && let Err(error) = foca_tx.send(FocaInput::ClusterSize(size)).await
+                        {
+                            tracing::error!(%error, "could not send new foca cluster size");
+                        }
+                    }
+
+                    "memberdown"
+                }
+                ON::Rename(a, b) => {
+                    let mut lock = members.0.write();
+                    lock.remove_member(&a);
+                    lock.add_member(&b);
+
+                    tracing::info!(old = ?a, new = ?b, "Member Rename");
+
+                    "rename"
+                }
+                ON::Active => {
+                    tracing::info!("Current node is considered ACTIVE");
+                    "active"
+                }
+                ON::Idle => {
+                    tracing::warn!("Current node is considered IDLE");
+                    "idle"
+                }
+                // this happens when we leave the cluster
+                ON::Defunct => {
+                    tracing::debug!("Current node is considered DEFUNCT");
+                    "defunct"
+                }
+                ON::Rejoin(id) => {
+                    tracing::info!(?id, "Rejoined the cluster");
+                    "rejoin"
+                }
+            };
+
+            metrics.swim_notification_inc(kind);
+        }
+    });
 }
 
 /// Load the existing known member state and addresses

--- a/crates/corrosion/src/gossip/swim.rs
+++ b/crates/corrosion/src/gossip/swim.rs
@@ -1193,10 +1193,9 @@ pub fn spawn_notification_handler(
                                 tracing::error!(%error, "could not send new foca cluster size");
                             }
                         }
-                        MemberAddedResult::Updated => {
+                        MemberAddedResult::Updated | MemberAddedResult::Ignored => {
                             // anything else to do here?
                         }
-                        MemberAddedResult::Ignored => {}
                     }
 
                     "memberup"

--- a/crates/corrosion/src/gossip/swim.rs
+++ b/crates/corrosion/src/gossip/swim.rs
@@ -1,0 +1,1165 @@
+use super::GossipMetrics;
+use bytes::{Bytes, BytesMut};
+use corro_types::{
+    actor::{self, Actor},
+    broadcast::{self as bx, FocaCmd, FocaInput},
+    members,
+    sqlite::unnest_param,
+};
+use foca::{Identity, Timer};
+use parking_lot::RwLock;
+use rand::{SeedableRng, rngs::StdRng};
+use std::{
+    collections::VecDeque,
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::sync::mpsc;
+use transport::Transport;
+use tripwire::PreemptibleFutureExt;
+
+type Foca = foca::Foca<
+    Actor,
+    foca::BincodeCodec<bincode::config::Configuration>,
+    StdRng,
+    foca::NoCustomBroadcast,
+>;
+
+pub struct DispatchRuntime {
+    pub to_send: mpsc::Sender<(Actor, Bytes)>,
+    pub to_schedule: mpsc::Sender<(Duration, Timer<Actor>)>,
+    pub notifications: mpsc::Sender<foca::OwnedNotification<Actor>>,
+    pub active: bool,
+    pub buf: BytesMut,
+    pub metrics: &'static GossipMetrics,
+}
+
+impl foca::Runtime<Actor> for DispatchRuntime {
+    fn notify(&mut self, notification: foca::Notification<'_, Actor>) {
+        match &notification {
+            foca::Notification::Active => {
+                self.active = true;
+            }
+            foca::Notification::Idle | foca::Notification::Defunct => {
+                self.active = false;
+            }
+            _ => {}
+        };
+
+        if self
+            .notifications
+            .try_send(notification.to_owned())
+            .is_err()
+        {
+            self.metrics
+                .channel_error_inc("full", "dispatch.notifications");
+        }
+    }
+
+    fn send_to(&mut self, to: Actor, data: &[u8]) {
+        self.buf.extend_from_slice(data);
+
+        if self
+            .to_send
+            .try_send((to, self.buf.split().freeze()))
+            .is_err()
+        {
+            self.metrics.channel_error_inc("full", "dispatch.to_send");
+        }
+    }
+
+    fn submit_after(&mut self, event: Timer<Actor>, after: Duration) {
+        if self.to_schedule.try_send((after, event)).is_err() {
+            self.metrics
+                .channel_error_inc("full", "dispatch.to_schedule");
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct SwimCtx {
+    pub pool: corro_types::agent::SplitPool,
+    pub members: Arc<parking_lot::RwLock<members::Members>>,
+    pub actor_id: actor::ActorId,
+    pub member_id: Option<actor::MemberId>,
+    pub cluster_id: actor::ClusterId,
+    pub metrics: &'static GossipMetrics,
+}
+
+/// Entry point for the SWIM-based gossip
+pub fn swim_loop(
+    ctx: SwimCtx,
+    actor: Actor,
+    transport: Transport,
+    mut foca_rx: mpsc::Receiver<FocaInput>,
+    bcast_rx: mpsc::Receiver<bx::BroadcastInput>,
+    to_send: mpsc::Sender<(Actor, Bytes)>,
+    notifications_tx: mpsc::Sender<foca::OwnedNotification<Actor>>,
+    tripwire: tripwire::Tripwire,
+    mut member_states: Vec<(std::net::SocketAddr, foca::Member<Actor>)>,
+) {
+    let rng = StdRng::from_os_rng();
+
+    let config = make_foca_config(1.try_into().unwrap());
+
+    let mut foca = Foca::with_custom_broadcast(
+        actor,
+        config.clone(),
+        rng,
+        foca::BincodeCodec(bincode::config::Configuration::default()),
+        foca::NoCustomBroadcast,
+    );
+
+    let config = Arc::new(RwLock::new(config));
+
+    let (to_schedule, mut to_schedule_rx) = mpsc::channel(512);
+
+    let mut runtime = DispatchRuntime {
+        to_send,
+        to_schedule,
+        notifications: notifications_tx.clone(),
+        active: false,
+        buf: Default::default(),
+        metrics: ctx.metrics,
+    };
+
+    let (timer_tx, mut timer_rx) = mpsc::channel(10);
+    let timer_spawner = TimerSpawner::new(timer_tx);
+
+    {
+        let mut tripwire = tripwire.clone();
+        spawn::spawn_counted(async move {
+            while let tripwire::Outcome::Completed(Some((duration, timer))) =
+                to_schedule_rx.recv().preemptible(&mut tripwire).await
+            {
+                timer_spawner.spawn((duration, timer));
+            }
+        });
+    }
+
+    let cluster_size = Arc::new(std::sync::atomic::AtomicU32::new(1));
+
+    // foca SWIM operations loop.
+    // NOTE: every turn of that loop should be fast or else we risk being a down suspect
+    spawn::spawn_counted({
+        let config = config.clone();
+        let agent = agent.clone();
+        let cluster_size = cluster_size.clone();
+        let mut tripwire = tripwire.clone();
+
+        async move {
+            let mut metrics_interval = tokio::time::interval(Duration::from_secs(10));
+            let mut last_cluster_size = std::num::NonZeroU32::new(1).unwrap();
+
+            let mut last_states = member_states
+                .into_iter()
+                .map(|(_, member)| (member, None))
+                .collect::<Vec<_>>();
+            let mut diff_last_states_every = tokio::time::interval(Duration::from_secs(60));
+
+            enum Branch {
+                Foca(FocaInput),
+                HandleTimer(Timer<Actor>, Instant),
+                DiffMembers,
+                Metrics,
+            }
+
+            loop {
+                let (branch, bdisc) = tokio::select! {
+                    biased;
+                    timer = timer_rx.recv() => {
+                        let Some((timer, seq)) = timer else {
+                            tracing::warn!("no more foca timers, breaking");
+                            break;
+                        };
+
+                        (Branch::HandleTimer(timer, seq), "handle_timer")
+                    },
+                    input = foca_rx.recv() => {
+                        let Some(input) = input else {
+                            tracing::warn!("no more foca inputs");
+                            break;
+                        };
+
+                        (Branch::Foca(input), "foca")
+                    },
+                    _ = metrics_interval.tick() => {
+                        (Branch::Metrics, "metrics")
+                    },
+                    _ = diff_last_states_every.tick() => {
+                        (Branch::DiffMembers, "diff_members")
+                    }
+                    _ = &mut tripwire => {
+                        break
+                    },
+                };
+
+                let start = Instant::now();
+
+                match branch {
+                    Branch::Foca(input) => 'foca: {
+                        match input {
+                            FocaInput::Announce(actor) => {
+                                if let Err(error) = foca.announce(actor, &mut runtime) {
+                                    tracing::error!(%error, "foca announce error");
+                                }
+                            }
+                            FocaInput::Data(data) => {
+                                if let Err(error) = foca.handle_data(&data, &mut runtime) {
+                                    tracing::error!(%error, "error handling foca data");
+                                }
+                            }
+                            FocaInput::ClusterSize(size) => {
+                                if size != last_cluster_size {
+                                    let new_config = make_foca_config(size);
+                                    if let Err(error) = foca.set_config(new_config.clone()) {
+                                        tracing::error!(%error, "foca set_config error");
+                                    } else {
+                                        last_cluster_size = size;
+                                        *config.write() = new_config;
+                                    }
+                                }
+
+                                cluster_size
+                                    .store(size.get(), std::sync::atomic::Ordering::Release);
+                            }
+                            FocaInput::ApplyMany(updates) => {
+                                if let Err(error) =
+                                    foca.apply_many(updates.into_iter(), true, &mut runtime)
+                                {
+                                    tracing::error!(%error, "foca apply_many error");
+                                }
+                            }
+                            FocaInput::Cmd(cmd) => match cmd {
+                                FocaCmd::Rejoin(callback) => {
+                                    let Some(renewed) = foca.identity().renew() else {
+                                        break 'foca;
+                                    };
+
+                                    let new_id = foca.change_identity(renewed, &mut runtime);
+
+                                    if callback.send(new_id).is_err() {
+                                        tracing::warn!(
+                                            "could not send back result after rejoining cluster"
+                                        );
+                                    }
+                                }
+                                FocaCmd::MembershipStates(sender) => {
+                                    for member in foca.iter_membership_state() {
+                                        if let Err(error) = sender.send(member.clone()).await {
+                                            tracing::error!(
+                                                %error,
+                                                "could not send back foca membership"
+                                            );
+                                            break;
+                                        }
+                                    }
+                                }
+                                FocaCmd::ChangeIdentity(id, callback) => {
+                                    if callback
+                                        .send(foca.change_identity(id, &mut runtime))
+                                        .is_err()
+                                    {
+                                        tracing::warn!(
+                                            "could not send back result after changing identity"
+                                        );
+                                    }
+                                }
+                            },
+                        }
+                    }
+                    Branch::HandleTimer(timer, seq) => {
+                        handle_timer(&mut foca, &mut runtime, &mut timer_rx, timer, seq);
+                    }
+                    Branch::Metrics => {
+                        // trace!("handling Branch::Metrics");
+                        // {
+                        //     gauge!("corro.gossip.members").set(foca.num_members() as f64);
+                        //     gauge!("corro.gossip.member.states")
+                        //         .set(foca.iter_membership_state().count() as f64);
+                        //     gauge!("corro.gossip.updates_backlog")
+                        //         .set(foca.updates_backlog() as f64);
+                        // }
+                        // {
+                        //     let config = config.read();
+                        //     gauge!("corro.gossip.config.max_transmissions")
+                        //         .set(config.max_transmissions.get() as f64);
+                        //     gauge!("corro.gossip.config.num_indirect_probes")
+                        //         .set(config.num_indirect_probes.get() as f64);
+                        // }
+                        // gauge!("corro.gossip.cluster_size").set(last_cluster_size.get() as f64);
+                    }
+                    Branch::DiffMembers => {
+                        diff_member_states(&ctx, &foca, &mut last_states, &notifications_tx);
+                    }
+                };
+
+                let elapsed = start.elapsed();
+                if elapsed > Duration::from_secs(1) {
+                    tracing::warn!(
+                        ?elapsed,
+                        branch = bdisc,
+                        "swim loop took excessive time to execute branch"
+                    );
+                }
+            }
+
+            // leave the cluster gracefully
+            if let Err(error) = foca.leave_cluster(&mut runtime) {
+                tracing::error!(%error, "could not leave cluster gracefully");
+            }
+
+            let leave_deadline = tokio::time::sleep(Duration::from_secs(5));
+            tokio::pin!(leave_deadline);
+
+            let mut foca_done = false;
+            let mut timer_done = false;
+
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = &mut leave_deadline => {
+                        break;
+                    },
+                    timer = timer_rx.recv(), if !timer_done => match timer {
+                        Some((timer, seq)) => {
+                            handle_timer(&mut foca, &mut runtime, &mut timer_rx, timer, seq);
+                        },
+                        None => {
+                            timer_done = true;
+                        }
+                    },
+                    input = foca_rx.recv(), if !foca_done => match input {
+                        Some(FocaInput::Data(data)) => {
+                            _ = foca.handle_data(&data, &mut runtime);
+                        },
+                        None => {
+                            foca_done = true
+                        }
+                        _ => {
+
+                        }
+                    },
+                    else => {
+                        break;
+                    }
+                }
+            }
+
+            if let Some(handle) =
+                diff_member_states(&ctx, &foca, &mut last_states, &notifications_tx)
+            {
+                tracing::debug!("Waiting on task to update member states...");
+                if let Err(error) = handle.await {
+                    tracing::error!(%error, "could not await task to update member states");
+                }
+            }
+
+            tracing::info!("foca runtime loop is done, leaving cluster");
+        }
+    });
+
+    spawn::spawn_counted(handle_broadcasts(
+        ctx, bcast_rx, transport, config, tripwire,
+    ));
+}
+
+fn make_foca_config(cluster_size: std::num::NonZeroU32) -> foca::Config {
+    let mut config = foca::Config::new_wan(cluster_size);
+
+    config.remove_down_after = Duration::from_secs(2 * 24 * 3600);
+    config.max_packet_size = std::num::NonZeroUsize::new(1178).unwrap();
+
+    config
+}
+
+#[derive(Clone)]
+struct TimerSpawner {
+    send: mpsc::UnboundedSender<(Duration, Timer<Actor>)>,
+}
+
+impl TimerSpawner {
+    pub fn new(timer_tx: mpsc::Sender<(Timer<Actor>, Instant)>) -> Self {
+        let (send, mut recv) = mpsc::unbounded_channel();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+
+        std::thread::Builder::new()
+            .name("foca-runtime-timer".to_owned())
+            .spawn({
+                move || {
+                    let local = tokio::task::LocalSet::new();
+
+                    local.spawn_local(async move {
+                        while let Some((duration, timer)) = recv.recv().await {
+                            let seq = Instant::now() + duration;
+
+                            let timer_tx = timer_tx.clone();
+                            tokio::task::spawn_local(async move {
+                                tokio::time::sleep(duration).await;
+                                timer_tx.send((timer, seq)).await.ok();
+                            });
+                        }
+                        // If the while loop returns, then all the LocalSpawner
+                        // objects have been dropped.
+                    });
+
+                    // This will return once all senders are dropped and all
+                    // spawned tasks have returned.
+                    rt.block_on(local);
+                }
+            });
+
+        Self { send }
+    }
+
+    #[inline]
+    pub fn spawn(&self, task: (Duration, Timer<Actor>)) {
+        self.send
+            .send(task)
+            .expect("Thread with LocalSet has shut down.");
+    }
+}
+
+fn handle_timer(
+    foca: &mut Foca,
+    runtime: &mut DispatchRuntime,
+    timer_rx: &mut mpsc::Receiver<(Timer<Actor>, Instant)>,
+    timer: Timer<Actor>,
+    seq: Instant,
+) {
+    let mut v = vec![(timer, seq)];
+
+    // drain the channel, in case there's a race among timers
+    while let Ok((timer, seq)) = timer_rx.try_recv() {
+        v.push((timer, seq));
+    }
+
+    // sort by instant these were scheduled
+    v.sort_by(|a, b| a.1.cmp(&b.1));
+
+    for (timer, _) in v {
+        let Err(error) = foca.handle_timer(timer, &mut *runtime) else {
+            continue;
+        };
+
+        tracing::error!(%error, "foca: error handling timer");
+    }
+}
+
+fn diff_member_states(
+    ctx: &SwimCtx,
+    foca: &Foca,
+    last_states: &mut Vec<(foca::Member<Actor>, Option<u64>)>,
+    notifications_tx: &mpsc::Sender<foca::OwnedNotification<Actor>>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    let mut foca_states = Vec::<&foca::Member<Actor>>::new();
+    for member in foca.iter_membership_state() {
+        let Some(existing) = foca_states
+            .iter_mut()
+            .find(|fs| fs.id().id() == member.id().id())
+        else {
+            foca_states.push(member);
+            continue;
+        };
+
+        if existing.id().ts() < member.id().ts() {
+            *existing = member;
+        }
+    }
+
+    let (to_delete, to_update, foca_notifications) = {
+        let members = ctx.members.read();
+
+        let to_update = foca_states
+            .iter()
+            .filter_map(|member| {
+                let member = *member;
+
+                if member.id().member_id() != ctx.member_id {
+                    return None;
+                }
+
+                let rtt = members
+                    .rtts
+                    .get(&member.id().addr())
+                    .and_then(|rtts| rtts.buf.iter().min().copied());
+
+                let Some(prev) = last_states
+                    .iter_mut()
+                    .find(|ls| ls.0.id().id() == member.id().id())
+                else {
+                    last_states.push((member.clone(), rtt));
+                    return Some((member.clone(), rtt));
+                };
+
+                (prev.0 != *member || prev.1 != rtt).then(|| {
+                    last_states.push((member.clone(), rtt));
+                    (member.clone(), rtt)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let mut to_delete = vec![];
+
+        last_states.retain(|(mem, _)| {
+            if let Some(foca_state) = foca_states.iter().find(|fs| fs.id().id() == mem.id().id())
+                && foca_state.id().member_id() == ctx.member_id
+            {
+                true
+            } else {
+                to_delete.push(mem.id().id());
+                false
+            }
+        });
+
+        let mut foca_notifications = vec![];
+        foca_notifications.extend(foca_states.iter().filter_map(|fs| {
+            let member = *fs;
+            (foca_state_is_active(&member.state()) && members.get(&member.id().id()).is_none())
+                .then(|| foca::OwnedNotification::MemberUp(member.id().clone()))
+        }));
+
+        foca_notifications.extend(members.states.iter().filter_map(|(id, member_state)| {
+            let Some(fs) = foca_states.iter().find(|fs| fs.id().id() == *id) else {
+                return Some(foca::OwnedNotification::MemberDown(
+                    member_state.to_actor(*id),
+                ));
+            };
+
+            (!foca_state_is_active(&fs.state()))
+                .then(|| foca::OwnedNotification::MemberDown(fs.id().clone()))
+        }));
+
+        (to_delete, to_update, foca_notifications)
+    };
+
+    if !foca_notifications.is_empty() {
+        tracing::info!(
+            count = foca_notifications.len(),
+            "Sending out foca notifications for members",
+        );
+        // best effort update since we'd retry this function.
+        for notification in foca_notifications {
+            if notifications_tx.try_send(notification).is_err() {
+                ctx.metrics
+                    .channel_error_inc("full", "dispatch.notifications");
+            }
+        }
+    }
+
+    if to_update.is_empty() && to_delete.is_empty() {
+        return None;
+    }
+
+    tracing::info!(
+        update = to_update.len(),
+        delete = to_delete.len(),
+        "Scheduling cluster membership state update",
+    );
+
+    let updated_at = time::OffsetDateTime::now_utc();
+
+    let pool = ctx.pool.clone();
+    Some(tokio::spawn(async move {
+        let mut conn = match pool.write_low().await {
+            Ok(conn) => conn,
+            Err(error) => {
+                tracing::error!(%error, "could not acquire a r/w conn to process member events");
+                return;
+            }
+        };
+
+        let mut upserted = 0;
+        let mut deleted = 0;
+
+        let res = tokio::task::block_in_place(|| {
+            let tx = conn.immediate_transaction()?;
+
+            upserted += tx
+                .prepare_cached(
+                    "
+                INSERT INTO __corro_members (actor_id, address, foca_state, rtt_min, updated_at)
+                    SELECT                   value0,   value1,  value2,     value3, value4
+                    FROM              unnest(?,        ?,       ?,          ?,       ?)
+                    -- Otherwise sqlite will think ON CONFLICT is part of a JOIN
+                    WHERE true
+                    ON CONFLICT (actor_id)
+                        DO UPDATE SET
+                            foca_state = excluded.foca_state,
+                            address = excluded.address,
+                            rtt_min = COALESCE(excluded.rtt_min, rtt_min),
+                            updated_at = excluded.updated_at
+                        WHERE excluded.updated_at > updated_at
+            ",
+                )?
+                .execute(rusqlite::params![
+                    unnest_param(to_update.iter().map(|(member, _)| member.id().id())),
+                    unnest_param(
+                        to_update
+                            .iter()
+                            .map(|(member, _)| member.id().addr().to_string())
+                    ),
+                    unnest_param(
+                        to_update
+                            .iter()
+                            .map(|(member, _)| serde_json::to_string(&member).unwrap())
+                    ),
+                    unnest_param(to_update.iter().map(|(_, rtt_min)| rtt_min)),
+                    unnest_param(to_update.iter().map(|_| updated_at)),
+                ])?;
+
+            deleted += tx
+                .prepare_cached(
+                    r#"DELETE FROM __corro_members
+                            WHERE actor_id IN (SELECT value0 FROM UNNEST(?))
+                            AND updated_at < ?
+                        "#,
+                )?
+                .execute(rusqlite::params![
+                    unnest_param(to_delete.iter()),
+                    updated_at
+                ])?;
+
+            tx.commit()?;
+
+            Ok::<_, rusqlite::Error>(())
+        });
+
+        if let Err(error) = res {
+            tracing::error!(%error, "could not insert state changes from SWIM cluster into sqlite");
+        }
+
+        tracing::info!(upserted, deleted, "membership states changed");
+    }))
+}
+
+struct PendingBroadcast {
+    payload: Bytes,
+    is_local: bool,
+    sent_to: Vec<SocketAddr>,
+    send_count: u8,
+}
+
+impl PendingBroadcast {
+    pub fn new(payload: Bytes) -> Self {
+        Self {
+            payload,
+            is_local: false,
+            sent_to: Default::default(),
+            send_count: 0,
+        }
+    }
+
+    pub fn new_local(payload: Bytes) -> Self {
+        Self {
+            payload,
+            is_local: true,
+            sent_to: Default::default(),
+            send_count: 0,
+        }
+    }
+}
+
+type BroadcastRateLimiter = governor::RateLimiter<
+    governor::state::NotKeyed,
+    governor::state::InMemoryState,
+    governor::clock::QuantaClock,
+    governor::middleware::StateInformationMiddleware,
+>;
+
+async fn handle_broadcasts(
+    ctx: SwimCtx,
+    mut bcast_rx: mpsc::Receiver<bx::BroadcastInput>,
+    transport: Transport,
+    config: Arc<RwLock<foca::Config>>,
+    mut tripwire: tripwire::Tripwire,
+) {
+    use bytes::BufMut;
+    use futures::stream::FusedStream;
+    use speedy::Writable;
+    use tokio_stream::StreamExt;
+    use tokio_util::codec::Encoder;
+
+    // max broadcast size
+    let broadcast_cutoff: usize = 64 * 1024;
+
+    let mut bcast_codec = tokio_util::codec::LengthDelimitedCodec::builder()
+        .max_frame_length(10 * 1_024 * 1_024)
+        .new_codec();
+
+    let mut bcast_buf = BytesMut::new();
+    let mut local_bcast_buf = BytesMut::new();
+    let mut single_bcast_buf = BytesMut::new();
+
+    let mut metrics_interval = tokio::time::interval(Duration::from_secs(10));
+
+    let mut rng = StdRng::from_os_rng();
+
+    let mut idle_pendings = futures_util::stream::FuturesUnordered::<
+        std::pin::Pin<Box<dyn Future<Output = PendingBroadcast> + Send + 'static>>,
+    >::new();
+
+    let mut bcast_interval = tokio::time::interval(Duration::from_millis(500));
+
+    enum Branch {
+        Broadcast(bx::BroadcastInput),
+        BroadcastDeadline,
+        WokePendingBroadcast(PendingBroadcast),
+        Tripped,
+        Metrics,
+    }
+
+    let mut tripped = false;
+    let mut ser_buf = BytesMut::new();
+
+    let mut join_set = tokio::task::JoinSet::new();
+    let max_queue_len = agent.config().perf.processing_queue_len;
+    const MAX_INFLIGHT_BROADCAST: usize = 500;
+    let mut to_broadcast = VecDeque::new();
+    let mut to_local_broadcast = VecDeque::new();
+    let mut log_count = 0;
+
+    let mut limited_log_count = 0;
+
+    let bytes_per_sec = governor::RateLimiter::direct(governor::Quota::per_second(
+        std::num::NonZeroU32::new(10 * 1024 * 1024).unwrap(),
+    ))
+    .with_middleware();
+
+    let mut rate_limited = false;
+
+    loop {
+        let branch = tokio::select! {
+            biased;
+            input = bcast_rx.recv() => {
+                let Some(input) = input else {
+                    tracing::warn!("no more SWIM inputs");
+                    break;
+                };
+
+                Branch::Broadcast(input)
+            },
+            _ = join_set.join_next(), if !join_set.is_empty() => {
+                // drains the joinset
+                continue;
+            },
+            _ = bcast_interval.tick() => {
+                Branch::BroadcastDeadline
+            },
+            maybe_woke = idle_pendings.next(), if !idle_pendings.is_terminated() => {
+                let Some(woke) = maybe_woke else {
+                    continue;
+                };
+
+                Branch::WokePendingBroadcast(woke)
+            },
+            _ = &mut tripwire, if !tripped => {
+                tripped = true;
+                Branch::Tripped
+            },
+            _ = metrics_interval.tick() => {
+                Branch::Metrics
+            }
+        };
+
+        match branch {
+            Branch::Tripped => {
+                break;
+            }
+            Branch::BroadcastDeadline => {
+                if !bcast_buf.is_empty() {
+                    to_broadcast.push_front(PendingBroadcast::new(bcast_buf.split().freeze()));
+                }
+                if !local_bcast_buf.is_empty() {
+                    to_broadcast.push_front(PendingBroadcast::new_local(
+                        local_bcast_buf.split().freeze(),
+                    ));
+                }
+            }
+            Branch::Broadcast(input) => {
+                let (bcast, is_local) = match input {
+                    bx::BroadcastInput::Rebroadcast(bcast) => (bcast, false),
+                    bx::BroadcastInput::AddBroadcast(bcast) => (bcast, true),
+                };
+
+                if let Err(error) = (bx::UniPayload::V1 {
+                    data: bx::UniPayloadV1::Broadcast(bcast.clone()),
+                    cluster_id: ctx.cluster_id,
+                })
+                .write_to_stream((&mut ser_buf).writer())
+                {
+                    tracing::error!(%error, "could not encode UniPayload::Broadcast");
+                    ser_buf.clear();
+                    continue;
+                }
+
+                if is_local {
+                    if let Err(error) =
+                        bcast_codec.encode(ser_buf.split().freeze(), &mut single_bcast_buf)
+                    {
+                        tracing::error!(%error, "could not encode local broadcast");
+                        single_bcast_buf.clear();
+                        continue;
+                    }
+
+                    let payload = single_bcast_buf.split().freeze();
+
+                    local_bcast_buf.extend_from_slice(&payload);
+
+                    to_local_broadcast.push_front(payload);
+
+                    if local_bcast_buf.len() >= broadcast_cutoff {
+                        to_broadcast.push_front(PendingBroadcast::new_local(
+                            local_bcast_buf.split().freeze(),
+                        ));
+                    }
+                } else {
+                    if let Err(error) = bcast_codec.encode(ser_buf.split().freeze(), &mut bcast_buf)
+                    {
+                        tracing::error!(%error, "could not encode broadcast");
+                        bcast_buf.clear();
+                        continue;
+                    }
+
+                    if bcast_buf.len() >= broadcast_cutoff {
+                        to_broadcast.push_front(PendingBroadcast::new(bcast_buf.split().freeze()));
+                    }
+                }
+            }
+            Branch::WokePendingBroadcast(pending) => {
+                to_broadcast.push_front(pending);
+            }
+            Branch::Metrics => {
+                // gauge!("corro.broadcast.pending.count").set(idle_pendings.len() as f64);
+                // gauge!("corro.broadcast.processing.jobs").set(join_set.len() as f64);
+                // gauge!("corro.broadcast.buffer.capacity").set(bcast_buf.capacity() as f64);
+                // gauge!("corro.broadcast.serialization.buffer.capacity")
+                //     .set(ser_buf.capacity() as f64);
+            }
+        }
+
+        let prev_rate_limited = std::mem::take(&mut rate_limited);
+
+        // start with local broadcasts, they're higher priority
+        let mut ring0 = HashSet::new();
+        while !to_local_broadcast.is_empty() && join_set.len() < MAX_INFLIGHT_BROADCAST {
+            // UNWRAP: we just checked that it wasn't empty
+            let payload = to_local_broadcast.pop_front().unwrap();
+
+            let members = ctx.members.read();
+            let mut spawn_count = 0;
+            let mut ring0_count = 0;
+            for addr in members.ring0(ctx.cluster_id) {
+                if join_set.len() >= MAX_INFLIGHT_BROADCAST {
+                    tracing::debug!(
+                        MAX_INFLIGHT_BROADCAST,
+                        "breaking, max inflight broadcast reached",
+                    );
+                    break;
+                }
+                ring0_count += 1;
+                ring0.insert(addr);
+
+                match try_transmit_broadcast(
+                    &bytes_per_sec,
+                    payload.clone(),
+                    transport.clone(),
+                    addr,
+                ) {
+                    Err(e) => {
+                        match e {
+                            TransmitError::TooBig(_) | TransmitError::InsufficientCapacity(_) => {
+                                // not sure this would ever happen
+                                error!("could not spawn broadcast transmission: {e}");
+                                continue;
+                            }
+                            TransmitError::QuotaExceeded(_) => {
+                                // exceeded our quota, stop trying to send this through
+                                rate_limited = true;
+                                counter!("corro.broadcast.rate_limited").increment(1);
+                                break;
+                            }
+                        }
+                    }
+                    Ok(fut) => {
+                        join_set.spawn(fut);
+                        spawn_count += 1;
+                    }
+                }
+            }
+
+            // couldn't send it anywhere!
+            if rate_limited && spawn_count == 0 && ring0_count > 0 {
+                // push it back in front since this got nowhere and it's still the
+                // freshest item we have in the queue
+                to_local_broadcast.push_front(payload);
+                break;
+            }
+
+            counter!("corro.broadcast.spawn", "type" => "local").increment(spawn_count);
+        }
+
+        if !rate_limited && !to_broadcast.is_empty() && join_set.len() < MAX_INFLIGHT_BROADCAST {
+            let (members_count, ring0_count) = {
+                let members = agent.members().read();
+                let members_count = members.states.len();
+                let ring0_count = members.ring0(agent.cluster_id()).count();
+                (members_count, ring0_count)
+            };
+
+            let (choose_count, max_transmissions) = {
+                let config = config.read();
+                let max_transmissions = config.max_transmissions.get();
+                let dynamic_count =
+                    (members_count - ring0_count) / (max_transmissions as usize * 10);
+                let count = cmp::max(config.num_indirect_probes.get(), dynamic_count);
+
+                if prev_rate_limited {
+                    // we've been rate limited on the last loop, try sending to less nodes...
+                    (cmp::min(count, dynamic_count / 2), max_transmissions / 2)
+                } else {
+                    (count, max_transmissions)
+                }
+            };
+
+            while !to_broadcast.is_empty() && join_set.len() < MAX_INFLIGHT_BROADCAST {
+                let mut pending = to_broadcast.pop_front().unwrap();
+
+                let broadcast_to = {
+                    agent
+                        .members()
+                        .read()
+                        .states
+                        .iter()
+                        .filter_map(|(member_id, state)| {
+                            // don't broadcast to ourselves... or ring0 if local broadcast
+                            // (ring0 could have changed since the time we sent the local broadcast
+                            // so we check the ring0 variable that's created at start of local_broacast
+                            // instead of state.is_ring0())
+                            if *member_id == actor_id
+                                || state.cluster_id != agent.cluster_id()
+                                || (pending.is_local && ring0.contains(&state.addr))
+                                || pending.sent_to.contains(&state.addr)
+                            // don't broadcast to this peer
+                            {
+                                None
+                            } else {
+                                Some(state.addr)
+                            }
+                        })
+                        .choose_multiple(
+                            &mut rng,
+                            // prevent going over max count
+                            cmp::min(
+                                choose_count,
+                                MAX_INFLIGHT_BROADCAST.saturating_sub(join_set.len()),
+                            ),
+                        )
+                };
+
+                let mut spawn_count = 0;
+                trace!("broadcasting to: {:?}", broadcast_to);
+                for addr in broadcast_to {
+                    match try_transmit_broadcast(
+                        &bytes_per_sec,
+                        pending.payload.clone(),
+                        transport.clone(),
+                        addr,
+                    ) {
+                        Err(e) => {
+                            warn!("could not spawn broadcast transmission: {e}");
+                            match e {
+                                TransmitError::TooBig(_)
+                                | TransmitError::InsufficientCapacity(_) => {
+                                    // not sure this would ever happen
+                                    continue;
+                                }
+                                TransmitError::QuotaExceeded(_) => {
+                                    // exceeded our quota, stop trying to send this through
+                                    counter!("corro.broadcast.rate_limited").increment(1);
+                                    log_at_pow_10(
+                                        "broadcasts rate limited",
+                                        &mut limited_log_count,
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        Ok(fut) => {
+                            debug!(actor = %actor_id, "broadcasting {} bytes to: {addr}", pending.payload.len());
+                            join_set.spawn(fut);
+                            pending.sent_to.insert(addr);
+                            spawn_count += 1;
+                        }
+                    }
+                }
+
+                counter!("corro.broadcast.spawn", "type" => "global").increment(spawn_count);
+
+                if let Some(send_count) = pending.send_count.checked_add(1) {
+                    trace!("send_count: {send_count}, max_transmissions: {max_transmissions}");
+                    pending.send_count = send_count;
+
+                    if send_count < max_transmissions {
+                        debug!("queueing for re-send");
+                        idle_pendings.push(Box::pin(async move {
+                            // slow our send pace if we've been previously rate limited
+                            let sleep_ms_base = if prev_rate_limited { 500 } else { 100 };
+                            // send with increasing latency as we've already sent the updates out
+                            tokio::time::sleep(Duration::from_millis(
+                                sleep_ms_base * send_count as u64,
+                            ))
+                            .await;
+                            pending
+                        }));
+                    }
+                }
+            }
+        }
+
+        if drop_oldest_broadcast(&mut to_broadcast, &mut to_local_broadcast, max_queue_len)
+            .is_some()
+        {
+            ctx.metrics.broadcast_dropped_inc();
+        }
+    }
+
+    tracing::info!("SWIM broadcasts are done");
+}
+
+#[inline]
+fn foca_state_is_active(state: &foca::State) -> bool {
+    matches!(*state, foca::State::Alive | foca::State::Suspect)
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TransmitError {
+    #[error("payload > u32::MAX: {0}")]
+    TooBig(usize),
+    #[error(transparent)]
+    InsufficientCapacity(#[from] governor::InsufficientCapacity),
+    #[error("{0}")]
+    QuotaExceeded(governor::NotUntil<governor::clock::QuantaInstant>),
+}
+
+fn try_transmit_broadcast(
+    bytes_per_sec: &BroadcastRateLimiter,
+    payload: Bytes,
+    transport: Transport,
+    addr: SocketAddr,
+    metrics: &'static GossipMetrics,
+) -> Result<std::pin::Pin<Box<dyn Future<Output = ()> + Send>>, TransmitError> {
+    let len = payload.len();
+
+    let Some(len_u32) = len.try_into().ok().and_then(std::num::NonZeroU32::new) else {
+        return Err(TransmitError::TooBig(len));
+    };
+
+    match bytes_per_sec.check_n(len_u32) {
+        Ok(Ok(state)) => {
+            metrics.broadcast_remaining_burst(state.remaining_burst_capacity());
+        }
+        Ok(Err(e)) => return Err(TransmitError::QuotaExceeded(e)),
+        Err(e) => return Err(e.into()),
+    }
+
+    Ok(Box::pin(async move {
+        match tokio::time::timeout(Duration::from_secs(5), transport.send_uni(addr, payload)).await
+        {
+            Err(_e) => {
+                tracing::warn!(%addr, "timed out writing broadcast to uni broadcast stream");
+            }
+            Ok(Err(error)) => {
+                tracing::error!(%error, %addr, "could not write to uni broadcast stream");
+            }
+            Ok(Ok(_)) => {
+                metrics.stream_bytes_inc(
+                    len as _,
+                    quinn::Dir::Uni,
+                    super::metrics::Direction::Out,
+                    "broadcast",
+                );
+            }
+        }
+    }))
+}
+
+// Drop the oldest, most sent item or the oldest local item
+fn drop_oldest_broadcast(
+    queue: &mut VecDeque<PendingBroadcast>,
+    local_queue: &mut VecDeque<Bytes>,
+    max: usize,
+) -> Option<PendingBroadcast> {
+    if queue.len() + local_queue.len() <= max {
+        return None;
+    }
+
+    // start by dropping from global queue
+    if let Some((i, _)) = queue
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, val)| val.send_count)
+    {
+        queue.remove(i)
+    } else {
+        local_queue.pop_back().map(PendingBroadcast::new_local)
+    }
+}
+
+/// Load the existing known member state and addresses
+pub async fn load_member_states(
+    pool: &corro_types::agent::SplitPool,
+) -> Vec<(std::net::SocketAddr, foca::Member<Actor>)> {
+    let conn = match pool.read().await {
+        Ok(conn) => conn,
+        Err(error) => {
+            tracing::error!(%error, "could not acquire conn for foca member states");
+            return Vec::new();
+        }
+    };
+
+    use eyre::WrapErr;
+
+    let res = tokio::task::block_in_place(
+        || -> eyre::Result<Vec<(std::net::SocketAddr, foca::Member<Actor>)>> {
+            let mut prepped = conn
+                .prepare("SELECT address,foca_state FROM __corro_members")
+                .context("could not prepare query")?;
+            let members = prepped
+                .query_map([], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?.parse().map_err(|e| {
+                            rusqlite::Error::FromSqlConversionFailure(
+                                0,
+                                rusqlite::types::Type::Text,
+                                Box::new(e),
+                            )
+                        })?,
+                        row.get::<_, String>(1)?,
+                    ))
+                })
+                .and_then(|rows| {
+                    rows.collect::<rusqlite::Result<Vec<(std::net::SocketAddr, String)>>>()
+                })
+                .context("could not query")?;
+
+            Ok(members.into_iter().filter_map(|(address, state)| match serde_json::from_str::<foca::Member<Actor>>(state.as_str()) {
+            Ok(fs) => Some((address, fs)),
+            Err(error) => {
+                tracing::error!(%error, state, "could not deserialize foca member state");
+                None
+            }
+        }).collect::<Vec<(std::net::SocketAddr, foca::Member<Actor>)>>())
+        },
+    );
+
+    res.inspect_err(|error| {
+        tracing::error!(%error, "unable to read foca member state");
+    })
+    .unwrap_or_default()
+}

--- a/crates/corrosion/src/gossip/sync.rs
+++ b/crates/corrosion/src/gossip/sync.rs
@@ -123,7 +123,7 @@ async fn read_sync_msg(
     match read.next().await {
         Some(buf_res) => match buf_res {
             Ok(mut buf) => {
-                stream_metrics.incoming(&buf);
+                stream_metrics.incoming(&buf, crate::gossip::transport::TrafficClass::Sync);
 
                 match SyncMessage::from_buf(&mut buf) {
                     Ok(SyncMessage::V1(sm)) => Ok(Some(sm)),
@@ -181,7 +181,8 @@ impl<'m> Writer<'m> {
         let len = self.send.len();
         send.write_chunk(self.send.split().freeze()).await?;
 
-        self.metrics.outgoing(len as _);
+        self.metrics
+            .outgoing(len as _, super::transport::TrafficClass::Sync);
 
         Ok(())
     }

--- a/crates/corrosion/src/gossip/sync.rs
+++ b/crates/corrosion/src/gossip/sync.rs
@@ -1,0 +1,976 @@
+use super::{GossipContext, StreamMetrics, metrics::Direction};
+use bytes::{BufMut, BytesMut};
+use corro_types::{
+    actor::{self, ActorId},
+    agent,
+    base::{CrsqlDbVersion, CrsqlDbVersionRange, CrsqlSeq, CrsqlSeqRange},
+    bookie::Bookie,
+    broadcast as bx, change as cx,
+    sync::{self, SyncMessage, SyncMessageV1, SyncNeedV1, SyncRequestV1},
+};
+use quinn::SendStream;
+use speedy::Writable;
+use std::time::Duration;
+use tokio::{io::AsyncWriteExt, sync::mpsc};
+use tokio_stream::StreamExt;
+use tokio_util::codec::{self, Encoder, LengthDelimitedCodec};
+use tracing::Instrument;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SyncSendError {
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Write(#[from] quinn::WriteError),
+    #[error(transparent)]
+    Rusqlite(#[from] rusqlite::Error),
+    #[error("expected a column, there were none")]
+    NoMoreColumns,
+    #[error("expected column '{0}', got none")]
+    MissingColumn(&'static str),
+    #[error("expected column '{0}', got '{1}'")]
+    WrongColumn(&'static str, String),
+    #[error("unexpected column '{0}'")]
+    UnexpectedColumn(String),
+    #[error("unknown resource state")]
+    UnknownResourceState,
+    #[error("unknown resource type")]
+    UnknownResourceType,
+    #[error("wrong ip byte len: {0}")]
+    WrongIpByteLength(usize),
+    #[error("could not encode message: {0}")]
+    Encode(#[from] sync::SyncMessageEncodeError),
+    #[error("sync send channel is closed")]
+    ChannelClosed,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SyncRecvError {
+    #[error("could not decode message: {0}")]
+    Decoded(#[from] sync::SyncMessageDecodeError),
+    #[error(transparent)]
+    Change(#[from] agent::ChangeError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error("expected sync state message, received something else")]
+    ExpectedSyncState,
+    #[error("unexpected end of stream")]
+    UnexpectedEndOfStream,
+    #[error("expected sync clock message, received something else")]
+    ExpectedClockMessage,
+    #[error("timed out waiting for sync message")]
+    TimedOut(#[from] tokio::time::error::Elapsed),
+    #[error("changes channel is closed")]
+    ChangesChannelClosed,
+    #[error("requests channel is closed")]
+    RequestsChannelClosed,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BiPayloadEncodeError {
+    #[error(transparent)]
+    Encode(#[from] speedy::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BiPayloadSendError {
+    #[error("could not encode payload: {0}")]
+    Encode(#[from] BiPayloadEncodeError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Write(#[from] quinn::WriteError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    #[error(transparent)]
+    Connect(#[from] quinn::ConnectError),
+    #[error(transparent)]
+    Connection(#[from] quinn::ConnectionError),
+    #[error(transparent)]
+    Datagram(#[from] quinn::SendDatagramError),
+    #[error(transparent)]
+    SendStreamWrite(#[from] quinn::WriteError),
+    #[error(transparent)]
+    TimedOut(#[from] tokio::time::error::Elapsed),
+    #[error(transparent)]
+    Stopped(#[from] quinn::StoppedError),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SyncError {
+    #[error(transparent)]
+    Send(#[from] SyncSendError),
+    #[error(transparent)]
+    BiPayloadSend(#[from] BiPayloadSendError),
+    #[error(transparent)]
+    Recv(#[from] SyncRecvError),
+    #[error(transparent)]
+    Rejection(#[from] sync::SyncRejectionV1),
+    #[error(transparent)]
+    Transport(#[from] TransportError),
+}
+
+async fn read_sync_msg(
+    read: &mut codec::FramedRead<quinn::RecvStream, codec::LengthDelimitedCodec>,
+    stream_metrics: &super::StreamMetrics,
+) -> Result<Option<SyncMessageV1>, SyncRecvError> {
+    use tokio_stream::StreamExt;
+
+    match read.next().await {
+        Some(buf_res) => match buf_res {
+            Ok(mut buf) => {
+                stream_metrics.incoming(&buf);
+
+                match SyncMessage::from_buf(&mut buf) {
+                    Ok(SyncMessage::V1(sm)) => Ok(Some(sm)),
+                    Err(e) => Err(SyncRecvError::from(e)),
+                }
+            }
+            Err(e) => Err(SyncRecvError::from(e)),
+        },
+        None => Ok(None),
+    }
+}
+
+struct Writer<'m> {
+    codec: LengthDelimitedCodec,
+    encode: BytesMut,
+    send: BytesMut,
+    metrics: &'m StreamMetrics,
+}
+
+impl<'m> Writer<'m> {
+    #[inline]
+    fn new(metrics: &'m StreamMetrics) -> Self {
+        Self {
+            codec: LengthDelimitedCodec::builder()
+                .max_frame_length(100 * 1_024 * 1_024)
+                .new_codec(),
+            encode: BytesMut::new(),
+            send: BytesMut::new(),
+            metrics,
+        }
+    }
+
+    #[inline]
+    fn encode(&mut self, msg: SyncMessageV1) -> Result<(), SyncSendError> {
+        SyncMessage::V1(msg)
+            .write_to_stream((&mut self.encode).writer())
+            .map_err(sync::SyncMessageEncodeError::from)?;
+
+        let data = self.encode.split().freeze();
+        self.codec.encode(data, &mut self.send)?;
+        Ok(())
+    }
+
+    #[inline]
+    async fn send_if_non_empty(&mut self, send: &mut SendStream) -> Result<(), SyncSendError> {
+        if !self.send.is_empty() {
+            self.send(send).await?;
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    async fn send(&mut self, send: &mut SendStream) -> Result<(), SyncSendError> {
+        let len = self.send.len();
+        send.write_chunk(self.send.split().freeze()).await?;
+
+        self.metrics.outgoing(len as _);
+
+        Ok(())
+    }
+
+    #[inline]
+    async fn encode_and_send(
+        &mut self,
+        msg: SyncMessageV1,
+        send: &mut SendStream,
+    ) -> Result<(), SyncSendError> {
+        self.encode(msg)?;
+        self.send(send).await?;
+        Ok(())
+    }
+}
+
+pub(super) async fn serve_sync(
+    ctx: GossipContext,
+    stream_metrics: super::StreamMetrics,
+    remote_actor_id: ActorId,
+    remote_cluster_id: actor::ClusterId,
+    _trace_ctx: sync::SyncTraceContextV1,
+    mut recv: codec::FramedRead<quinn::RecvStream, codec::LengthDelimitedCodec>,
+    mut send: SendStream,
+) -> Result<usize, SyncError> {
+    tracing::debug!("received sync request");
+
+    let mut writer = Writer::new(&stream_metrics);
+
+    // Reject sync requests from different clusters. This is how corro-agent does it, but it would be simpler to just
+    // close the stream with a specific error code IMO
+    if remote_cluster_id != ctx.cluster_id {
+        writer
+            .encode_and_send(
+                SyncMessageV1::Rejection(sync::SyncRejectionV1::DifferentCluster),
+                &mut send,
+            )
+            .await?;
+        return Ok(0);
+    }
+
+    // The first message after a sync request should always be the remote actor's clock
+    match read_sync_msg(&mut recv, &stream_metrics).await? {
+        Some(SyncMessageV1::Clock(ts)) => {
+            if let Err(error) = ctx.clock.update_with_timestamp(remote_actor_id, ts) {
+                tracing::warn!(error, %remote_actor_id, "could not update clock from remote actor");
+            }
+        }
+        Some(_) => return Err(SyncRecvError::ExpectedClockMessage.into()),
+        None => return Err(SyncRecvError::UnexpectedEndOfStream.into()),
+    }
+
+    let Ok(_permit) = ctx.sync_permits.try_acquire() else {
+        writer
+            .encode_and_send(
+                SyncMessageV1::Rejection(sync::SyncRejectionV1::MaxConcurrencyReached),
+                &mut send,
+            )
+            .await?;
+        return Ok(0);
+    };
+
+    let sync_state = generate_sync(&ctx).await;
+
+    // first, send the current sync state
+    writer
+        .encode_and_send(SyncMessageV1::State(sync_state), &mut send)
+        .await?;
+
+    // then the current clock's timestamp
+    writer
+        .encode_and_send(SyncMessageV1::Clock(ctx.clock.new_timestamp()), &mut send)
+        .await?;
+
+    // ensure we flush here so the data gets there fast. clock needs to be fresh!
+    send.flush().await.map_err(SyncSendError::from)?;
+
+    let (tx_need, rx_need) = mpsc::channel(1024);
+    let (tx, mut rx) = mpsc::channel::<SyncMessageV1>(256);
+
+    tokio::spawn({
+        let pool = ctx.pool.clone();
+        let bookie = ctx.bookie.clone();
+
+        async move {
+            if let Err(error) = process_sync(pool, bookie, tx, rx_need)
+                .instrument(tracing::trace_span!("process_sync", %remote_actor_id))
+                .await
+            {
+                tracing::error!(%error, "failed to process sync request");
+            }
+        }
+    });
+
+    let stream_metrics = std::pin::pin!(&stream_metrics);
+
+    let (send_res, recv_res) = tokio::join!(
+        async move {
+            let mut count = 0;
+            let mut check_buf = tokio::time::interval(Duration::from_secs(1));
+            let mut stopped = false;
+
+            loop {
+                tokio::select! {
+                    biased;
+                    stopped_res = send.stopped() => {
+                        match stopped_res {
+                            Ok(Some(code)) => {
+                                tracing::debug!(%code, "send stream was stopped by peer");
+                            },
+                            Ok(None) => {
+                                tracing::debug!("send stream was stopped by us");
+                            }
+                            Err(error) => {
+                                tracing::warn!(%error, "error waiting for stop from stream");
+                            }
+                        }
+                        stopped = true;
+                        break;
+                    },
+                    maybe_msg = rx.recv() => {
+                        let Some(msg) = maybe_msg else {
+                            break;
+                        };
+
+                        if let SyncMessageV1::Changeset(change) = &msg {
+                            count += change.len();
+                        }
+
+                        writer.encode(msg)?;
+
+                        if writer.send.len() >= 16 * 1024 {
+                            writer.send(&mut send).await?;
+                        }
+                    },
+                    _ = check_buf.tick() => {
+                        writer.send_if_non_empty(&mut send).await?;
+                    }
+                }
+            }
+
+            if !stopped {
+                writer.send_if_non_empty(&mut send).await?;
+
+                if let Err(error) = send.finish() {
+                    tracing::warn!(%error, "could not properly finish gossip send stream");
+                } else if let Err(error) = send.stopped().await {
+                    tracing::warn!(%error, "could not properly wait for gossip send stream to stop");
+                }
+            }
+
+            tracing::debug!(actor_id = %ctx.actor_id, count, "done writing sync messages");
+
+            ctx.metrics.sync_changes_inc(count as _, Direction::Out);
+
+            Ok::<_, SyncError>(count)
+        }.instrument(tracing::info_span!("process_versions_to_send", %remote_actor_id)),
+        async move {
+            let mut count = 0;
+
+            loop {
+                let msg = match read_sync_msg(&mut recv, &stream_metrics).await {
+                    Ok(None) => {
+                        break;
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, "sync recv error");
+                        break;
+                    }
+                    Ok(Some(msg)) => msg,
+                };
+
+                match msg {
+                    SyncMessageV1::Request(req) => {
+                        count += req
+                            .iter()
+                            .map(|(_, needs)| {
+                                needs.iter().map(|need| need.count()).sum::<usize>()
+                            })
+                            .sum::<usize>();
+                        tx_need
+                            .send(req)
+                            .await
+                            .map_err(|_e| SyncRecvError::RequestsChannelClosed)?;
+                    }
+                    SyncMessageV1::Changeset(_) => {
+                        tracing::warn!("received sync changeset message unexpectedly, ignoring");
+                    }
+                    SyncMessageV1::State(_) => {
+                        tracing::warn!("received sync state message unexpectedly, ignoring");
+                    }
+                    SyncMessageV1::Clock(_) => {
+                        tracing::warn!("received sync clock message more than once, ignoring");
+                    }
+                    SyncMessageV1::Rejection(rejection) => {
+                        return Err(rejection.into())
+                    }
+                }
+            }
+
+            tracing::debug!(local_actor_id = %ctx.actor_id, "done reading sync messages");
+
+            ctx.metrics.sync_requests_inc(count as u64, Direction::In);
+
+            Ok(count)
+        }.instrument(tracing::info_span!("process_version_requests", %remote_actor_id))
+    );
+
+    if let Err(error) = send_res {
+        tracing::error!(%remote_actor_id, %error, "could not complete serving sync due to a send side error");
+    }
+
+    recv_res
+}
+
+// Generates a `SyncMessage` to tell another node what versions we're missing
+async fn generate_sync(ctx: &GossipContext) -> sync::SyncStateV1 {
+    let mut state = sync::SyncStateV1 {
+        actor_id: ctx.actor_id,
+        ..Default::default()
+    };
+
+    let bookie = &ctx.bookie;
+    let guard = bookie.owned_guard();
+
+    for (&actor_id, booked) in bookie.iter(&guard) {
+        let bookedr = booked.read();
+
+        let last_version = match bookedr.last() {
+            None => continue,
+            Some(v) => v,
+        };
+
+        let need = bookedr.needed().iter().cloned().collect::<Vec<_>>();
+
+        if !need.is_empty() {
+            state.need.insert(actor_id, need);
+        }
+
+        {
+            for (v, partial) in bookedr
+                .partials
+                .iter()
+                // don't set partial if it is effectively complete
+                .filter(|(_, partial)| !partial.is_complete())
+            {
+                state.partial_need.entry(actor_id).or_default().insert(
+                    *v,
+                    partial
+                        .seqs
+                        .gaps(&(CrsqlSeq(0)..=partial.last_seq))
+                        .collect(),
+                );
+            }
+        }
+        state.heads.insert(actor_id, last_version);
+    }
+
+    state
+}
+
+async fn process_sync(
+    pool: corro_types::agent::SplitPool,
+    bookie: Bookie,
+    sender: mpsc::Sender<SyncMessageV1>,
+    recv: mpsc::Receiver<SyncRequestV1>,
+) -> eyre::Result<()> {
+    use futures::TryStreamExt;
+
+    let chunked_reqs = tokio_stream::wrappers::ReceiverStream::new(recv)
+        .chunks_timeout(10, Duration::from_millis(500));
+    tokio::pin!(chunked_reqs);
+
+    let (job_tx, job_rx) = mpsc::unbounded_channel();
+
+    let mut buf = futures::StreamExt::buffer_unordered(
+        tokio_stream::wrappers::UnboundedReceiverStream::<
+            std::pin::Pin<Box<dyn Future<Output = eyre::Result<()>> + Send>>,
+        >::new(job_rx),
+        6,
+    );
+    loop {
+        let reqs = tokio::select! {
+            Some(reqs) = chunked_reqs.next() => {
+                reqs
+            },
+            Some(res) = buf.next() => {
+                res?;
+                continue;
+            },
+            else => {
+                break;
+            }
+        };
+
+        use itertools::Itertools;
+
+        let agg = reqs
+            .into_iter()
+            .flatten()
+            .chunk_by(|req| req.0)
+            .into_iter()
+            .map(|(actor_id, reqs)| (actor_id, reqs.flat_map(|(_, reqs)| reqs).collect()))
+            .collect::<Vec<(ActorId, Vec<SyncNeedV1>)>>();
+
+        for (actor_id, needs) in agg {
+            let Some(booked) = bookie.get(&actor_id) else {
+                continue;
+            };
+
+            let booked_read = booked.read();
+
+            for need in needs {
+                match &need {
+                    SyncNeedV1::Full { versions } => {
+                        if versions.clone().all(|v| {
+                            booked_read.needed().contains(&v)
+                                || booked_read.last().is_some_and(|max| v > max)
+                        }) {
+                            continue;
+                        }
+                    }
+                    SyncNeedV1::Partial { version, .. } => {
+                        if booked_read.needed().contains(version)
+                            || booked_read.last().is_some_and(|max| *version > max)
+                        {
+                            continue;
+                        }
+                    }
+                    SyncNeedV1::Empty { .. } => {
+                        tracing::debug!("received empty need");
+                    }
+                }
+
+                let pool = pool.clone();
+                let sender = sender.clone();
+
+                let fut = Box::pin(async move {
+                    let mut conn = pool.read().await?;
+
+                    tokio::task::block_in_place(|| {
+                        handle_need(&mut conn, actor_id, need, &sender)
+                    })?;
+
+                    Ok(())
+                });
+
+                if job_tx.send(fut).is_err() {
+                    eyre::bail!("could not send into job channel");
+                }
+            }
+        }
+    }
+
+    tracing::debug!("gossip sync server loop finished");
+
+    drop(job_tx);
+
+    let _: () = buf.try_collect().await?;
+
+    tracing::debug!("finished processing gossip sync state");
+
+    Ok(())
+}
+
+fn send_change_chunks<I: Iterator<Item = rusqlite::Result<cx::Change>>>(
+    tx: &mpsc::Sender<SyncMessageV1>,
+    mut chunked: cx::ChunkedChanges<I>,
+    actor_id: ActorId,
+    version: CrsqlDbVersion,
+    last_seq: CrsqlSeq,
+    ts: bx::Timestamp,
+) -> eyre::Result<()> {
+    const ADAPT_CHUNK_SIZE_THRESHOLD: Duration = Duration::from_millis(500);
+    const MIN_CHANGES_BYTES_PER_MESSAGE: usize = 1024;
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let mut max_buf_size = chunked.max_buf_size();
+    loop {
+        eyre::ensure!(!tx.is_closed(), "sync message sender channel is closed");
+
+        match chunked.next() {
+            Some(Ok((changes, seqs))) => {
+                if changes.is_empty() && seqs.start() == CrsqlSeq(0) && seqs.end() == last_seq {
+                    tracing::warn!(%actor_id, %version, "got an empty changes we should've had");
+                    return Ok(());
+                }
+
+                let start = std::time::Instant::now();
+
+                tx.blocking_send(SyncMessageV1::Changeset(bx::ChangeV1 {
+                    actor_id,
+                    changeset: bx::Changeset::FullV2 {
+                        actor_id,
+                        version,
+                        changes,
+                        seqs,
+                        last_seq,
+                        ts,
+                    },
+                }))?;
+
+                let elapsed = start.elapsed();
+
+                eyre::ensure!(elapsed <= TIMEOUT, "time out: peer is too slow");
+
+                if elapsed <= ADAPT_CHUNK_SIZE_THRESHOLD {
+                    continue;
+                }
+
+                eyre::ensure!(
+                    max_buf_size > MIN_CHANGES_BYTES_PER_MESSAGE,
+                    "time out: peer is too slow even after reducing throughput"
+                );
+
+                max_buf_size /= 2;
+                chunked.set_max_buf_size(max_buf_size);
+            }
+            Some(Err(error)) => {
+                tracing::error!(%actor_id, %version, %error, "could not process changes to send via sync");
+                break;
+            }
+            None => {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_need(
+    conn: &mut rusqlite::Connection,
+    actor_id: ActorId,
+    need: SyncNeedV1,
+    sender: &mpsc::Sender<SyncMessageV1>,
+) -> eyre::Result<()> {
+    use bx::Timestamp;
+    use corro_types::change::row_to_change;
+    use rangemap::RangeInclusiveSet as Ris;
+    use rusqlite::named_params;
+
+    const MAX_CHANGES_BYTES_PER_MESSAGE: usize = 8 * 1024;
+
+    let mut empties = Ris::<CrsqlDbVersion>::new();
+
+    // this is a read transaction!
+    let tx = conn.transaction()?;
+    let timeout = Some(Duration::from_secs(60));
+    let tx = sqlite_pool::InterruptibleTransaction::new(tx, timeout, "handle_need");
+
+    let mut prepped = tx.prepare_cached(
+        "
+        SELECT db_version, MAX(seq) AS last_seq, MAX(ts) AS ts
+            FROM crsql_changes
+            WHERE site_id = :actor_id
+              AND db_version BETWEEN :start AND :end
+            GROUP BY db_version
+            ORDER BY db_version DESC, seq ASC
+    ",
+    )?;
+
+    match need {
+        SyncNeedV1::Full { versions } => {
+            let mut rows = prepped.query(named_params! {
+                ":actor_id": actor_id,
+                ":start": versions.start(),
+                ":end": versions.end(),
+            })?;
+
+            let mut unprocessed = Ris::new();
+            unprocessed.insert(versions.into());
+
+            loop {
+                let row = match rows.next()? {
+                    Some(row) => row,
+                    None => {
+                        break;
+                    }
+                };
+
+                let version: CrsqlDbVersion = row.get(0)?;
+
+                unprocessed.remove(version..=version);
+
+                let last_seq: CrsqlSeq = row.get(1)?;
+                let ts: Timestamp = row.get(2)?;
+
+                let mut prepped = tx.prepare_cached(
+                    r#"
+                        SELECT "table", pk, cid, val, col_version, db_version, seq, site_id, cl, ts
+                            FROM crsql_changes
+                            WHERE site_id = :actor_id
+                              AND db_version = :version
+                            ORDER BY seq ASC
+                    "#,
+                )?;
+
+                let rows = prepped.query_map(
+                    rusqlite::named_params! {
+                        ":actor_id": actor_id,
+                        ":version": version
+                    },
+                    row_to_change,
+                )?;
+
+                send_change_chunks(
+                    sender,
+                    cx::ChunkedChanges::new(
+                        rows,
+                        CrsqlSeq(0),
+                        last_seq,
+                        MAX_CHANGES_BYTES_PER_MESSAGE,
+                    ),
+                    actor_id,
+                    version,
+                    last_seq,
+                    ts,
+                )?;
+            }
+
+            // now process the last unprocessed in case we have partials
+            for versions in unprocessed {
+                for version in CrsqlDbVersionRange::from(versions) {
+                    let (in_gaps, buffered): (bool, bool) = tx
+                        .prepare_cached(
+                            "
+                        SELECT
+                            EXISTS(
+                                SELECT 1
+                                FROM __corro_bookkeeping_gaps
+                                    WHERE actor_id = :actor_id
+                                      AND :version BETWEEN start AND end
+                            ) AS in_gaps,
+                            EXISTS(
+                                SELECT 1
+                                FROM __corro_buffered_changes
+                                    WHERE site_id = :actor_id
+                                      AND db_version = :version
+                            ) AS buffered",
+                        )?
+                        .query_row(
+                            named_params! {
+                                ":actor_id": actor_id,
+                                ":version": version
+                            },
+                            |row| Ok((row.get(0)?, row.get(1)?)),
+                        )?;
+
+                    if !buffered {
+                        if !in_gaps {
+                            // this is an empty!
+                            empties.insert(version..=version);
+                        }
+                        continue;
+                    }
+
+                    let seqs = tx
+                        .prepare_cached("
+                        SELECT start_seq, end_seq, last_seq, ts FROM __corro_seq_bookkeeping WHERE site_id = :actor_id AND db_version = :db_version
+                        ")?.query_map(named_params!{
+                            ":actor_id": actor_id,
+                            ":db_version": version
+                        },|row| Ok((CrsqlSeqRange::new(row.get(0)?, row.get(1)?), row.get(2)?, row.get(3)?)))?.collect::<rusqlite::Result<Vec<(CrsqlSeqRange, CrsqlSeq, Timestamp)>>>()?;
+
+                    for (range_needed, last_seq, ts) in seqs {
+                        let mut prepped = tx.prepare_cached(
+                            r#"
+                                SELECT "table", pk, cid, val, col_version, db_version, seq, site_id, cl
+                                    FROM __corro_buffered_changes
+                                    WHERE site_id = :actor_id
+                                        AND db_version = :db_version
+                                        AND seq BETWEEN :start_seq AND :end_seq
+                                    ORDER BY seq ASC
+                            "#,
+                        )?;
+
+                        let start_seq = range_needed.start();
+                        let end_seq = range_needed.end();
+
+                        let rows = prepped.query_map(
+                            named_params! {
+                                ":actor_id": actor_id,
+                                ":db_version": version,
+                                ":start_seq": start_seq,
+                                ":end_seq": end_seq
+                            },
+                            row_to_change,
+                        )?;
+
+                        send_change_chunks(
+                            sender,
+                            cx::ChunkedChanges::new(
+                                rows,
+                                start_seq,
+                                end_seq,
+                                MAX_CHANGES_BYTES_PER_MESSAGE,
+                            ),
+                            actor_id,
+                            version,
+                            last_seq,
+                            ts,
+                        )?;
+                    }
+                }
+            }
+        }
+        SyncNeedV1::Partial { version, seqs } => {
+            let mut rows = prepped.query(named_params! {
+                ":actor_id": actor_id,
+                ":start": version,
+                ":end": version,
+            })?;
+
+            if let Some(row) = rows.next()? {
+                let version: CrsqlDbVersion = row.get(0)?;
+                let last_seq: CrsqlSeq = row.get(1)?;
+                let ts: bx::Timestamp = row.get(2)?;
+
+                for range_needed in seqs {
+                    let mut prepped = tx.prepare_cached(
+                        r#"
+                            SELECT "table", pk, cid, val, col_version, db_version, seq, site_id, cl
+                                FROM crsql_changes
+                                WHERE site_id = :actor_id
+                                  AND db_version = :version
+                                  AND seq BETWEEN :start AND :end
+                                ORDER BY seq ASC
+                        "#,
+                    )?;
+
+                    let rows = prepped.query_map(
+                        named_params! {
+                            ":actor_id": actor_id,
+                            ":version": version,
+                            ":start": range_needed.start(),
+                            ":end": range_needed.end(),
+                        },
+                        row_to_change,
+                    )?;
+
+                    send_change_chunks(
+                        sender,
+                        cx::ChunkedChanges::new(
+                            rows,
+                            range_needed.start(),
+                            range_needed.end(),
+                            MAX_CHANGES_BYTES_PER_MESSAGE,
+                        ),
+                        actor_id,
+                        version,
+                        last_seq,
+                        ts,
+                    )?;
+                }
+            } else {
+                let (in_gaps, buffered): (bool, bool) = tx
+                    .prepare_cached(
+                        "
+                        SELECT
+                            EXISTS(
+                                SELECT 1
+                                FROM __corro_bookkeeping_gaps
+                                    WHERE actor_id = :actor_id
+                                      AND :version BETWEEN start AND end
+                            ) AS in_gaps,
+                            EXISTS(
+                                SELECT 1
+                                FROM __corro_buffered_changes
+                                    WHERE site_id = :actor_id
+                                      AND db_version = :version
+                            ) AS buffered",
+                    )?
+                    .query_row(
+                        named_params! {
+                            ":actor_id": actor_id,
+                            ":version": version
+                        },
+                        |row| Ok((row.get(0)?, row.get(1)?)),
+                    )?;
+
+                if !buffered && !in_gaps {
+                    // this is an empty!
+                    empties.insert(version..=version);
+                }
+
+                if buffered {
+                    for seqs_range in seqs {
+                        let seqs = tx
+                            .prepare_cached(
+                                "
+                                SELECT start_seq, end_seq, last_seq, ts
+                                    FROM __corro_seq_bookkeeping
+                                    WHERE
+                                        site_id = :actor_id AND
+                                        db_version = :db_version AND
+                                        (
+                                            -- [:start]---[start_seq]---[:end]
+                                            ( start_seq BETWEEN :start AND :end ) OR
+
+                                            -- [start_seq]---[:start]---[:end]---[end_seq]
+                                            ( start_seq <= :start AND end_seq >= :end ) OR
+
+                                            -- [:start]---[start_seq]---[:end]---[end_seq]
+                                            ( start_seq <= :end AND end_seq >= :end ) OR
+
+                                            -- [:start]---[end_seq]---[:end]
+                                            ( end_seq BETWEEN :start AND :end )
+                                        )
+                                ",
+                            )?
+                            .query_map(
+                                named_params! {
+                                    ":actor_id": actor_id,
+                                    ":db_version": version,
+                                    ":start": seqs_range.start(),
+                                    ":end": seqs_range.end(),
+                                },
+                                |row| {
+                                    Ok((
+                                        CrsqlSeqRange::new(row.get(0)?, row.get(1)?),
+                                        row.get(2)?,
+                                        row.get(3)?,
+                                    ))
+                                },
+                            )?
+                            .collect::<rusqlite::Result<Vec<(CrsqlSeqRange, CrsqlSeq, Timestamp)>>>(
+                            )?;
+
+                        for (range_needed, last_seq, ts) in seqs {
+                            let mut prepped = tx.prepare_cached(
+                                r#"
+                                    SELECT "table", pk, cid, val, col_version, db_version, seq, site_id, cl
+                                        FROM __corro_buffered_changes
+                                        WHERE site_id = :actor_id
+                                            AND db_version = :version
+                                            AND seq BETWEEN :start_seq AND :end_seq
+                                        ORDER BY seq ASC
+                                "#,
+                            )?;
+
+                            // scope query to only the sequences we have
+                            let start_seq = std::cmp::max(range_needed.start(), seqs_range.start());
+                            let end_seq = std::cmp::min(range_needed.end(), seqs_range.end());
+
+                            let rows = prepped.query_map(
+                                named_params! {
+                                    ":actor_id": actor_id,
+                                    ":version": version,
+                                    ":start_seq": start_seq,
+                                    ":end_seq": end_seq
+                                },
+                                row_to_change,
+                            )?;
+
+                            send_change_chunks(
+                                sender,
+                                cx::ChunkedChanges::new(
+                                    rows,
+                                    start_seq,
+                                    end_seq,
+                                    MAX_CHANGES_BYTES_PER_MESSAGE,
+                                ),
+                                actor_id,
+                                version,
+                                last_seq,
+                                ts,
+                            )?;
+                        }
+                    }
+                }
+            }
+        }
+        SyncNeedV1::Empty { .. } => {
+            // NOTE: no more empties in the new reality
+        }
+    }
+
+    if !empties.is_empty() {
+        for versions in empties {
+            sender.blocking_send(SyncMessageV1::Changeset(bx::ChangeV1 {
+                actor_id,
+                changeset: bx::Changeset::Empty {
+                    versions: versions.into(),
+                    ts: None,
+                },
+            }))?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/corrosion/src/gossip/transport.rs
+++ b/crates/corrosion/src/gossip/transport.rs
@@ -4,16 +4,14 @@ use quinn::{self as q, Connection};
 use std::{
     collections::HashMap,
     net::SocketAddr,
-    sync::{Arc, Mutex as StdMutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 use tokio::sync::{Mutex, RwLock, mpsc};
-use tracing::Instrument;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Transport(Arc<TransportInner>);
 
-#[derive(Debug)]
 struct TransportInner {
     endpoint: q::Endpoint,
     conns: RwLock<HashMap<SocketAddr, Arc<Mutex<Option<Connection>>>>>,
@@ -22,7 +20,7 @@ struct TransportInner {
 }
 
 #[derive(Clone, Copy)]
-pub(crate) enum TrafficClass {
+pub enum TrafficClass {
     Sync,
     Broadcast,
     Foca,
@@ -95,52 +93,37 @@ impl Transport {
             }
         }
 
-        self.0.metrics.client_datagrams_sent_inc(data.len());
+        self.0
+            .metrics
+            .client_chunks_sent_inc(data.len(), TrafficClass::Foca);
 
         Ok(())
     }
 
     pub async fn send_uni(&self, addr: SocketAddr, data: Bytes) -> Result<(), TransportError> {
-        let len = data.len();
         let conn = self.connect(addr, TrafficClass::Broadcast).await?;
 
-        let mut stream = match conn
-            .open_uni()
-            .instrument(debug_span!("quic_open_uni"))
-            .await
-        {
+        let mut stream = match conn.open_uni().await {
             Ok(stream) => stream,
-            Err(e @ ConnectionError::VersionMismatch) => {
+            Err(e @ q::ConnectionError::VersionMismatch) => {
                 return Err(e.into());
             }
-            Err(e) => {
-                debug!("retryable error attempting to open unidirectional stream: {e}");
+            Err(_e) => {
                 let conn = self.connect(addr, TrafficClass::Broadcast).await?;
-                conn.open_uni()
-                    .instrument(debug_span!("quic_open_uni"))
-                    .await?
+                conn.open_uni().await?
             }
         };
 
-        stream
-            .write_chunk(data)
-            .instrument(debug_span!("quic_write_chunk"))
-            .await?;
+        let len = data.len();
+        stream.write_chunk(data).await?;
 
-        stream
-            .finish()
-            .expect("unreachable, the stream does not leave this method");
+        let _dont_care = stream.finish();
 
-        stream
-            .stopped()
-            .instrument(debug_span!("quic_stopped"))
-            .await?;
+        stream.stopped().await?;
 
-        counter!(
-            "corro.transport.tx.bytes.v2.total",
-            "traffic" => TrafficClass::Broadcast.as_str()
-        )
-        .increment(len as u64);
+        self.0
+            .metrics
+            .client_chunks_sent_inc(len, TrafficClass::Broadcast);
 
         Ok(())
     }
@@ -181,30 +164,27 @@ impl Transport {
         .await
         {
             Ok(Ok(conn)) => {
-                histogram!(
-                    "corro.transport.connect.time.v2.seconds",
-                    "traffic" => traffic.as_str()
-                )
-                .record(start.elapsed().as_secs_f64());
-                tracing::Span::current().record("rtt", conn.rtt().as_secs_f64());
+                self.0.metrics.client_connect_time(start.elapsed(), traffic);
                 Ok(conn)
             }
             Ok(Err(e)) => {
-                counter!(
-                    "corro.transport.connect.errors.v2",
-                    "traffic" => traffic.as_str(),
-                    "kind" => "connect_error"
-                )
-                .increment(1);
+                let err_str = match &e {
+                    q::ConnectionError::VersionMismatch => "version_mismatch",
+                    q::ConnectionError::ApplicationClosed(_) => "application_closed",
+                    q::ConnectionError::ConnectionClosed(_) => "connection_closed",
+                    q::ConnectionError::TransportError(_) => "transport",
+                    q::ConnectionError::LocallyClosed => "locally_closed",
+                    q::ConnectionError::Reset => "reset",
+                    q::ConnectionError::TimedOut => "quic_timed_out",
+                    q::ConnectionError::CidsExhausted => "cids_exhausted",
+                };
+
+                self.0.metrics.client_connect_error(traffic, err_str);
+
                 Err(e.into())
             }
             Err(e) => {
-                counter!(
-                    "corro.transport.connect.errors.v2",
-                    "traffic" => traffic.as_str(),
-                    "kind" => "timed_out"
-                )
-                .increment(1);
+                self.0.metrics.client_connect_error(traffic, "timed_out");
                 Err(e.into())
             }
         }

--- a/crates/corrosion/src/gossip/transport.rs
+++ b/crates/corrosion/src/gossip/transport.rs
@@ -61,9 +61,22 @@ impl Transport {
     ) -> eyre::Result<Self> {
         let mut endpoint = q::Endpoint::client((std::net::Ipv6Addr::UNSPECIFIED, 0).into())?;
 
-        // The original corrosion code puts timeouts on the client side, but IMO it makes more sense to put timeouts
-        // on the server side even though the effect is the same
-        endpoint.set_default_client_config(quinn_plaintext::client_config());
+        let mut cfg = quinn_plaintext::client_config();
+
+        static TRANSPORT_CONFIG: std::sync::OnceLock<Arc<quinn::TransportConfig>> =
+            std::sync::OnceLock::new();
+
+        cfg.transport_config(
+            TRANSPORT_CONFIG
+                .get_or_init(|| {
+                    let mut tcfg = quinn::TransportConfig::default();
+                    // Send keep alive packets at half the time of the idle timeout set on the server
+                    tcfg.keep_alive_interval(Some(std::time::Duration::from_secs(15)));
+                    Arc::new(tcfg)
+                })
+                .clone(),
+        );
+        endpoint.set_default_client_config(cfg);
 
         Ok(Self(Arc::new(TransportInner {
             endpoint,

--- a/crates/corrosion/src/gossip/transport.rs
+++ b/crates/corrosion/src/gossip/transport.rs
@@ -1,0 +1,289 @@
+use super::GossipMetrics;
+use bytes::Bytes;
+use quinn::{self as q, Connection};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{Arc, Mutex as StdMutex},
+    time::{Duration, Instant},
+};
+use tokio::sync::{Mutex, RwLock, mpsc};
+use tracing::Instrument;
+
+#[derive(Debug, Clone)]
+pub struct Transport(Arc<TransportInner>);
+
+#[derive(Debug)]
+struct TransportInner {
+    endpoint: q::Endpoint,
+    conns: RwLock<HashMap<SocketAddr, Arc<Mutex<Option<Connection>>>>>,
+    rtt_tx: mpsc::Sender<(SocketAddr, Duration)>,
+    metrics: &'static GossipMetrics,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum TrafficClass {
+    Sync,
+    Broadcast,
+    Foca,
+}
+
+impl TrafficClass {
+    #[inline]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Sync => "sync",
+            Self::Broadcast => "broadcast",
+            Self::Foca => "foca",
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TransportError {
+    #[error(transparent)]
+    Connect(#[from] q::ConnectError),
+    #[error(transparent)]
+    Connection(#[from] q::ConnectionError),
+    #[error(transparent)]
+    Datagram(#[from] q::SendDatagramError),
+    #[error(transparent)]
+    SendStreamWrite(#[from] q::WriteError),
+    #[error(transparent)]
+    TimedOut(#[from] tokio::time::error::Elapsed),
+    #[error(transparent)]
+    Stopped(#[from] q::StoppedError),
+}
+
+impl Transport {
+    /// Creates a new transport that communicates in plaintext
+    pub fn new_insecure(
+        metrics: &'static GossipMetrics,
+        rtt_tx: mpsc::Sender<(SocketAddr, Duration)>,
+    ) -> eyre::Result<Self> {
+        let mut endpoint = q::Endpoint::client((std::net::Ipv6Addr::UNSPECIFIED, 0).into())?;
+
+        // The original corrosion code puts timeouts on the client side, but IMO it makes more sense to put timeouts
+        // on the server side even though the effect is the same
+        endpoint.set_default_client_config(quinn_plaintext::client_config());
+
+        Ok(Self(Arc::new(TransportInner {
+            endpoint,
+            conns: Default::default(),
+            rtt_tx,
+            metrics,
+        })))
+    }
+
+    pub async fn send_datagram(&self, addr: SocketAddr, data: Bytes) -> Result<(), TransportError> {
+        let conn = self.connect(addr, TrafficClass::Foca).await?;
+
+        match conn.send_datagram(data.clone()) {
+            Ok(()) => {}
+            Err(q::SendDatagramError::ConnectionLost(_)) => {
+                let conn = self.connect(addr, TrafficClass::Foca).await?;
+                conn.send_datagram(data.clone())?;
+            }
+            Err(error) => {
+                self.0
+                    .metrics
+                    .client_datagram_errors_inc(datagram_error_kind(&error));
+                if matches!(error, q::SendDatagramError::TooLarge) {
+                    tracing::warn!(%addr, len = data.len(), max = conn.max_datagram_size(), "attempted to send a larger-than-PMTU datagram");
+                }
+                return Err(error.into());
+            }
+        }
+
+        self.0.metrics.client_datagrams_sent_inc(data.len());
+
+        Ok(())
+    }
+
+    pub async fn send_uni(&self, addr: SocketAddr, data: Bytes) -> Result<(), TransportError> {
+        let len = data.len();
+        let conn = self.connect(addr, TrafficClass::Broadcast).await?;
+
+        let mut stream = match conn
+            .open_uni()
+            .instrument(debug_span!("quic_open_uni"))
+            .await
+        {
+            Ok(stream) => stream,
+            Err(e @ ConnectionError::VersionMismatch) => {
+                return Err(e.into());
+            }
+            Err(e) => {
+                debug!("retryable error attempting to open unidirectional stream: {e}");
+                let conn = self.connect(addr, TrafficClass::Broadcast).await?;
+                conn.open_uni()
+                    .instrument(debug_span!("quic_open_uni"))
+                    .await?
+            }
+        };
+
+        stream
+            .write_chunk(data)
+            .instrument(debug_span!("quic_write_chunk"))
+            .await?;
+
+        stream
+            .finish()
+            .expect("unreachable, the stream does not leave this method");
+
+        stream
+            .stopped()
+            .instrument(debug_span!("quic_stopped"))
+            .await?;
+
+        counter!(
+            "corro.transport.tx.bytes.v2.total",
+            "traffic" => TrafficClass::Broadcast.as_str()
+        )
+        .increment(len as u64);
+
+        Ok(())
+    }
+
+    pub async fn open_bi(
+        &self,
+        addr: SocketAddr,
+    ) -> Result<(q::SendStream, q::RecvStream), TransportError> {
+        let conn = self.connect(addr, TrafficClass::Sync).await?;
+
+        match conn.open_bi().await {
+            Ok(s) => return Ok(s),
+            Err(e @ q::ConnectionError::VersionMismatch) => {
+                return Err(e.into());
+            }
+            Err(error) => {
+                tracing::debug!(%error, "retryable error attempting to open bidirectional stream");
+            }
+        }
+
+        // retry, it should reconnect!
+        let conn = self.connect(addr, TrafficClass::Sync).await?;
+        Ok(conn.open_bi().await?)
+    }
+
+    async fn measured_connect(
+        &self,
+        addr: SocketAddr,
+        server_name: String,
+        traffic: TrafficClass,
+    ) -> Result<Connection, TransportError> {
+        let start = Instant::now();
+
+        match tokio::time::timeout(
+            Duration::from_secs(5),
+            self.0.endpoint.connect(addr, &server_name)?,
+        )
+        .await
+        {
+            Ok(Ok(conn)) => {
+                histogram!(
+                    "corro.transport.connect.time.v2.seconds",
+                    "traffic" => traffic.as_str()
+                )
+                .record(start.elapsed().as_secs_f64());
+                tracing::Span::current().record("rtt", conn.rtt().as_secs_f64());
+                Ok(conn)
+            }
+            Ok(Err(e)) => {
+                counter!(
+                    "corro.transport.connect.errors.v2",
+                    "traffic" => traffic.as_str(),
+                    "kind" => "connect_error"
+                )
+                .increment(1);
+                Err(e.into())
+            }
+            Err(e) => {
+                counter!(
+                    "corro.transport.connect.errors.v2",
+                    "traffic" => traffic.as_str(),
+                    "kind" => "timed_out"
+                )
+                .increment(1);
+                Err(e.into())
+            }
+        }
+    }
+
+    // this shouldn't block for long...
+    async fn get_lock(&self, addr: SocketAddr) -> Arc<Mutex<Option<Connection>>> {
+        {
+            let r = self.0.conns.read().await;
+            if let Some(lock) = r.get(&addr) {
+                return lock.clone();
+            }
+        }
+
+        let mut w = self.0.conns.write().await;
+        w.entry(addr).or_default().clone()
+    }
+
+    async fn connect(
+        &self,
+        addr: SocketAddr,
+        traffic: TrafficClass,
+    ) -> Result<Connection, TransportError> {
+        let conn_lock = self.get_lock(addr).await;
+
+        let mut lock = conn_lock.lock().await;
+
+        if let Some(conn) = lock.as_ref()
+            && test_conn(conn)
+        {
+            if self.0.rtt_tx.try_send((addr, conn.rtt())).is_err() {
+                tracing::debug!("could not send RTT for connection through sender");
+            }
+            return Ok(conn.clone());
+        }
+
+        // clear it, if there was one it didn't pass the test.
+        *lock = None;
+
+        let conn = self
+            .measured_connect(addr, addr.ip().to_string(), traffic)
+            .await?;
+        *lock = Some(conn.clone());
+        Ok(conn)
+    }
+}
+
+const NO_ERROR: q::VarInt = q::VarInt::from_u32(0);
+
+fn datagram_error_kind(e: &q::SendDatagramError) -> &'static str {
+    match e {
+        q::SendDatagramError::UnsupportedByPeer => "unsupported_by_peer",
+        q::SendDatagramError::Disabled => "disabled",
+        q::SendDatagramError::TooLarge => "too_large",
+        q::SendDatagramError::ConnectionLost(_) => "connection_lost",
+    }
+}
+
+#[inline]
+fn test_conn(conn: &Connection) -> bool {
+    use q::ConnectionError;
+
+    match conn.close_reason() {
+        None => true,
+        Some(
+            ConnectionError::TimedOut
+            | ConnectionError::Reset
+            | ConnectionError::LocallyClosed
+            | ConnectionError::ApplicationClosed(q::ApplicationClose {
+                error_code: NO_ERROR,
+                ..
+            }),
+        ) => {
+            // don't log, pretty normal stuff
+            false
+        }
+        Some(error) => {
+            tracing::warn!(%error, "cached connection was closed abnormally, reconnecting");
+            false
+        }
+    }
+}

--- a/crates/corrosion/src/lib.rs
+++ b/crates/corrosion/src/lib.rs
@@ -36,10 +36,12 @@ impl Clock {
         // The try_into().unwrap() is an unfortunate necessity, the uhlc lib only provides TryFrom implementations,
         // but the conversion literally cannot fail, it would only fail if corrosion actorid increased in size beyond
         // its current 16 bytes
-        self.0.update_with_timestamp(&uhlc::Timestamp::new(
-            ts.to_ntp64(),
-            actor_id.try_into().unwrap(),
-        ))
+        self.0
+            .update_with_timestamp(&uhlc::Timestamp::new(
+                ts.to_ntp64(),
+                actor_id.try_into().unwrap(),
+            ))
+            .map_err(|e| e.to_string())
     }
 
     #[inline]

--- a/crates/corrosion/src/lib.rs
+++ b/crates/corrosion/src/lib.rs
@@ -4,6 +4,7 @@ pub use tripwire::Tripwire;
 
 pub mod codec;
 pub mod db;
+pub mod gossip;
 pub mod metrics;
 pub mod persistent;
 pub mod pubsub;
@@ -19,5 +20,30 @@ pub fn ip_to_peer(ip: std::net::IpAddr) -> Peer {
     match ip {
         std::net::IpAddr::V4(v4) => Peer::new(v4.to_ipv6_mapped(), 0, 0, 0),
         std::net::IpAddr::V6(v6) => Peer::new(v6, 0, 0, 0),
+    }
+}
+
+#[derive(Clone)]
+pub struct Clock(pub std::sync::Arc<uhlc::HLC>);
+
+impl Clock {
+    #[inline]
+    pub fn update_with_timestamp(
+        &self,
+        actor_id: types::actor::ActorId,
+        ts: types::broadcast::Timestamp,
+    ) -> Result<(), String> {
+        // The try_into().unwrap() is an unfortunate necessity, the uhlc lib only provides TryFrom implementations,
+        // but the conversion literally cannot fail, it would only fail if corrosion actorid increased in size beyond
+        // its current 16 bytes
+        self.0.update_with_timestamp(&uhlc::Timestamp::new(
+            ts.to_ntp64(),
+            actor_id.try_into().unwrap(),
+        ))
+    }
+
+    #[inline]
+    pub fn new_timestamp(&self) -> types::broadcast::Timestamp {
+        self.0.new_timestamp().into()
     }
 }

--- a/crates/corrosion/src/persistent/mutator.rs
+++ b/crates/corrosion/src/persistent/mutator.rs
@@ -2,7 +2,7 @@
 //! and send events to subscribers whose queries match the applied mutations
 
 use crate::{
-    Peer, db,
+    Clock, Peer, db,
     db::SplitPoolReadExt,
     persistent::proto::{ExecResponse, ExecResult, v1 as p},
 };
@@ -12,16 +12,12 @@ use corro_types::{
     base::{CrsqlDbVersion, CrsqlSeq},
     broadcast, change,
     pubsub::SubsManager,
-    updates::match_changes,
+    updates::{UpdatesManager, match_changes},
 };
-use eyre::WrapErr;
 use quilkin_types::IcaoCode;
 use rusqlite::Transaction;
 use sqlite_pool::InterruptibleTransaction;
-use std::{
-    sync::Arc,
-    time::{Duration, Instant},
-};
+use std::time::{Duration, Instant};
 use tokio::sync::oneshot;
 
 pub type BroadcastTx = tokio::sync::mpsc::Sender<broadcast::BroadcastInput>;
@@ -57,8 +53,9 @@ pub struct Transactor {
     bookie: Bookie,
     booked: Booked,
     subs: SubsManager,
+    updates: Option<UpdatesManager>,
     tx: Option<BroadcastTx>,
-    clock: Arc<uhlc::HLC>,
+    clock: Clock,
     id: ActorId,
     full_purge_count: usize,
 }
@@ -72,26 +69,16 @@ pub struct BroadcastingTransactor {
 }
 
 impl BroadcastingTransactor {
-    pub async fn new(
+    pub fn new(
         id: ActorId,
-        clock: Arc<uhlc::HLC>,
+        clock: Clock,
         pool: SplitPool,
         subs: SubsManager,
+        updates: Option<UpdatesManager>,
+        bookie: Bookie,
+        booked: Booked,
         tx: Option<BroadcastTx>,
-    ) -> eyre::Result<Self> {
-        let start = Instant::now();
-        let all_booked = {
-            let conn = pool
-                .read_readonly()
-                .await
-                .context("failed to acquire read")?;
-            BookedVersions::load_all_from_conn(&conn).context("failed to load booked versions")?
-        };
-        tracing::info!("Loaded booked versions in {:?}", start.elapsed());
-
-        let bookie = Bookie::new(all_booked);
-        let booked = bookie.ensure(id);
-
+    ) -> Self {
         let (write_tx, write_rx) = tokio::sync::mpsc::channel(256);
 
         let inner = Transactor {
@@ -100,6 +87,7 @@ impl BroadcastingTransactor {
             booked,
             clock,
             subs,
+            updates,
             id,
             tx,
             full_purge_count: DEFAULT_FULL_PURGE_COUNT,
@@ -110,7 +98,7 @@ impl BroadcastingTransactor {
         let txr = inner.clone();
         tokio::spawn(async move { write_loop(txr, write_rx).await });
 
-        Ok(Self { inner, write_tx })
+        btx
     }
 
     /// Sets the number of oldest `servers` rows purged on the second recovery attempt.
@@ -230,7 +218,7 @@ impl Transactor {
 
             let ret = f(&tx)?;
 
-            let insert_info = insert_local_changes(actor_id, &clock, &tx, &mut book_writer)?;
+            let insert_info = insert_local_changes(actor_id, &clock.0, &tx, &mut book_writer)?;
             tx.commit().map_err(|source| ChangeError::Rusqlite {
                 source,
                 actor_id: Some(actor_id),
@@ -252,12 +240,21 @@ impl Transactor {
 
                     let pool = self.pool.clone();
                     let subs = self.subs.clone();
+                    let updates = self.updates.clone();
                     let tx = self.tx.clone();
 
                     spawn::spawn_counted(async move {
-                        if let Err(error) =
-                            broadcast_changes(&pool, actor_id, &subs, tx, db_version, last_seq, ts)
-                                .await
+                        if let Err(error) = broadcast_changes(
+                            &pool,
+                            actor_id,
+                            &subs,
+                            updates.as_ref(),
+                            tx,
+                            db_version,
+                            last_seq,
+                            ts,
+                        )
+                        .await
                         {
                             tracing::error!(%error, "failed to broadcast changes");
                         }
@@ -520,6 +517,7 @@ pub async fn broadcast_changes(
     pool: &SplitPool,
     actor_id: ActorId,
     subs: &SubsManager,
+    updates: Option<&UpdatesManager>,
     tx: Option<BroadcastTx>,
     db_version: CrsqlDbVersion,
     last_seq: CrsqlSeq,
@@ -555,6 +553,9 @@ pub async fn broadcast_changes(
                         ts,
                     };
                     match_changes(subs, &changeset, db_version);
+                    if let Some(updates) = updates {
+                        match_changes(updates, &changeset, db_version);
+                    }
 
                     if let Some(tx) = tx.clone() {
                         tokio::spawn(async move {

--- a/crates/corrosion/src/persistent/mutator.rs
+++ b/crates/corrosion/src/persistent/mutator.rs
@@ -99,7 +99,7 @@ impl BroadcastingTransactor {
         let txr = inner.clone();
         tokio::spawn(async move { write_loop(txr, write_rx).await });
 
-        btx
+        Self { inner, write_tx }
     }
 
     /// Sets the number of oldest `servers` rows purged on the second recovery attempt.

--- a/crates/corrosion/src/persistent/mutator.rs
+++ b/crates/corrosion/src/persistent/mutator.rs
@@ -69,6 +69,7 @@ pub struct BroadcastingTransactor {
 }
 
 impl BroadcastingTransactor {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: ActorId,
         clock: Clock,
@@ -199,7 +200,7 @@ impl Transactor {
         let actor_id = self.id;
         let start = Instant::now();
         let clock = self.clock.clone();
-        let ts = broadcast::Timestamp::from(clock.new_timestamp());
+        let ts = clock.new_timestamp();
 
         tokio::task::block_in_place(move || {
             let bookie_write = self.bookie.write_lock_blocking();
@@ -513,6 +514,7 @@ async fn write_loop(txr: Transactor, mut rx: tokio::sync::mpsc::Receiver<Pending
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn broadcast_changes(
     pool: &SplitPool,
     actor_id: ActorId,

--- a/crates/test/src/bin/loadtest/runner/corrosion.rs
+++ b/crates/test/src/bin/loadtest/runner/corrosion.rs
@@ -95,8 +95,10 @@ impl CorrosionHandle {
             db.pool.clone(),
             subs.clone(),
             None,
-        )
-        .await?;
+            db.bookie,
+            db.booked,
+            None,
+        );
 
         let trip = Trip::new();
         let pubsub_ctx = PubsubContext {

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,7 @@ all-features = true
 unmaintained = 'workspace'
 yanked = 'deny'
 ignore = [
+    { id = "RUSTSEC-2025-0141", reason = "bincode is unmaintained but it's currently not an issue, there are alternatives if we need to change" },
 ]
 
 [bans]
@@ -49,10 +50,7 @@ deny = [
 multiple-versions = "deny"
 skip = [
     { crate = "object@0.32.2", reason = "transitive dependency due to backtrace, backtrace is updated, but stable-eyre is using a feature that doesn't exist any longer, and can't update" },
-    { crate = "object@0.37.3", reason = "extremely deep transitive build dependency" },
-    { crate = "const-oid@0.9.6", reason = "pgwire -> x509-certificate uses this old version" },
     { crate = "miniz_oxide@0.7.4", reason = "pprof_util carries two different versions transitively" },
-    { crate = "fallible-iterator@0.2.0", reason = "several users of old version in corrosion crates" },
     { crate = "bitflags@1.3.2", reason = "corrosion again" },
     { crate = "itertools:<0.14", reason = "sigh" },
 ]
@@ -89,10 +87,7 @@ exceptions = [
     # This license should not really be used for code, but here we are
     { crate = "notify", allow = ["CC0-1.0"] },
     { crate = "webpki-roots", allow = ["CDLA-Permissive-2.0"] },
-    { crate = "ar_archive_writer", allow = ["Apache-2.0 WITH LLVM-exception"] },
     { crate = "foca", allow = ["MPL-2.0"] },
-    { crate = "enquote", allow = ["Unlicense"] },
-    { crate = "x509-certificate", allow = ["MPL-2.0"] }
 ]
 
 [[licenses.clarify]]

--- a/deny.toml
+++ b/deny.toml
@@ -51,7 +51,6 @@ multiple-versions = "deny"
 skip = [
     { crate = "object@0.32.2", reason = "transitive dependency due to backtrace, backtrace is updated, but stable-eyre is using a feature that doesn't exist any longer, and can't update" },
     { crate = "miniz_oxide@0.7.4", reason = "pprof_util carries two different versions transitively" },
-    { crate = "bitflags@1.3.2", reason = "corrosion again" },
     { crate = "itertools:<0.14", reason = "sigh" },
 ]
 skip-tree = [

--- a/src/service.rs
+++ b/src/service.rs
@@ -210,6 +210,34 @@ pub struct Service {
     )]
     corrosion_journal_size_limit: Option<u64>,
 
+    /// The port the corrosion gossip service listens on
+    #[clap(
+        long = "service.corrosion.gossip-port",
+        env = "QUILKIN_SERVICE_CORROSION_GOSSIP_PORT",
+        default_value_t = 7902
+    )]
+    corrosion_gossip_port: u16,
+
+    /// Whether the corrosion gossip service is enabled, required if setting gossip endpoints
+    ///
+    /// Note that this will only spawn a service if `service.mds` and thus the corrosion service itself is also enabled
+    #[clap(
+        long = "service.corrosion.gossip-enable",
+        env = "QUILKIN_SERVICE_CORROSION_GOSSIP_ENABLE"
+    )]
+    corrosion_gossip_enable: bool,
+
+    /// Address of other Quilkin nodes to exchange corrosion database state with
+    ///
+    /// Note that an error will occur if endpoints are provided but `service.corrosion.gossip-enable` is not true, but
+    /// it is possible to enable gossip without providing endpoints, allowing other services to connect to this instance
+    /// and connect to the mesh that way
+    #[clap(
+        long = "service.corrosion.gossip-endpoints",
+        env = "QUILKIN_SERVICE_CORROSION_GOSSIP_ENDPOINTS"
+    )]
+    corrosion_gossip_endpoints: Vec<crate::net::EndpointAddress>,
+
     // END CORROSION
     #[clap(long = "termination-timeout")]
     termination_timeout: Option<crate::cli::Duration>,
@@ -260,6 +288,9 @@ impl Default for Service {
             corrosion_server_reap: None,
             corrosion_max_page_count: None,
             corrosion_journal_size_limit: None,
+            corrosion_gossip_enable: false,
+            corrosion_gossip_port: 7902,
+            corrosion_gossip_endpoints: Vec::new(),
             termination_timeout: None,
             testing: false,
             xds_to_corrosion: None,
@@ -317,6 +348,27 @@ impl Service {
     /// Set the port used for the corrosion service
     pub fn corrosion_port(mut self, port: u16) -> Self {
         self.corrosion_port = port;
+        self
+    }
+
+    /// Enable the corrosion gossip service
+    pub fn corrosion_gossip(mut self) -> Self {
+        self.corrosion_gossip_enable = true;
+        self
+    }
+
+    /// Sets the port used by the corrosion gossip service
+    pub fn corrosion_gossip_port(mut self, port: u16) -> Self {
+        self.corrosion_gossip_port = port;
+        self
+    }
+
+    /// The endpoints of other
+    pub fn corrosion_gossip_endpoints(
+        mut self,
+        endpoints: Vec<crate::net::EndpointAddress>,
+    ) -> Self {
+        self.corrosion_gossip_endpoints = endpoints;
         self
     }
 
@@ -936,7 +988,12 @@ impl Service {
     ) -> eyre::Result<()> {
         use corrosion::types;
 
-        tracing::info!(port=%self.corrosion_port, "starting corrosion service");
+        tracing::info!(port = %self.corrosion_port, "starting corrosion service");
+
+        eyre::ensure!(
+            self.corrosion_gossip_endpoints.is_empty() || !self.corrosion_gossip_enable,
+            "corrosion gossip endpoints were specified without enabling the corrosion gossip service"
+        );
 
         let db_root = if let Some(cdb) = self.corrosion_db_path.clone() {
             std::fs::create_dir_all(&cdb)?;
@@ -982,16 +1039,22 @@ impl Service {
             }),
         )
         .await?;
+
         let subs = types::pubsub::SubsManager::default();
+        let updates = self
+            .corrosion_gossip_enable
+            .then(|| types::updates::UpdatesManager::default());
 
         let btx = corrosion::persistent::mutator::BroadcastingTransactor::new(
             db.actor_id,
             db.clock.clone(),
             db.pool.clone(),
             subs.clone(),
+            updates.clone(),
+            db.bookie.clone(),
+            db.booked.clone(),
             None,
-        )
-        .await?;
+        );
 
         // Spawn a task to update the DB and broadcast changes when the filter changes
         if let Some((mut filters, mut filters_sub)) = config
@@ -1211,6 +1274,21 @@ impl Service {
 
         // Tripwire is how corrosion communicates a shutdown was requested
         let trip = corrosion::pubsub::Trip::new();
+
+        if self.corrosion_gossip_enable {
+            use eyre::WrapErr;
+
+            self.spawn_gossip_service(
+                &db,
+                subs.clone(),
+                updates.unwrap(),
+                trip.tripwire(),
+                shutdown,
+            )
+            .await
+            .context("failed to spawn gossip service")?;
+        }
+
         let ps_ctx = corrosion::pubsub::PubsubContext::new(
             subs,
             sub_path,
@@ -1251,18 +1329,144 @@ impl Service {
             drop(finished.send(Ok(())));
         });
 
-        // TODO: Spawn the client and server to gossip changes with other nodes if we are so configured
+        Ok(())
+    }
 
-        // let cluster_id = {
-        //     let conn = pool.read().await?;
-        //     conn.query_row(
-        //         "SELECT value FROM __corro_state WHERE key = 'cluster_id'",
-        //         [],
-        //         |row| row.get(0),
-        //     )
-        //     .optional()?
-        //     .unwrap_or_default()
-        // };
+    async fn spawn_gossip_service(
+        &self,
+        db: &corrosion::db::InitializedDb,
+        subs: corrosion::types::pubsub::SubsManager,
+        updates: corrosion::types::updates::UpdatesManager,
+        tripwire: corrosion::Tripwire,
+        shutdown: &mut ShutdownHandler,
+    ) -> eyre::Result<()> {
+        use corrosion::gossip;
+        use eyre::WrapErr;
+        use tokio::sync::mpsc::channel;
+
+        let metrics = gossip::GossipMetrics::new(crate::metrics::registry());
+
+        // Note that all of the various hardcoded numbers here are taken from the corrosion defaults, we should
+        // make them configurable and/or tune the numbers based on our usage in the future
+
+        // Foca is the library corrosion uses to manage the cluster's SWIM state, the state is transmitted via QUIC
+        // datagrams
+        let (foca_tx, foca_rx) = channel(256);
+        let (changes_tx, changes_rx) = channel(1024);
+        let (rtt_tx, rtt_rx) = channel(128);
+        let (broadcast_tx, broadcast_rx) = channel(512);
+        let (to_send_tx, to_send_rx) = channel(512);
+        let (notifications_tx, notifications_rx) = channel(512);
+        let (apply_tx, apply_rx) = channel(2048);
+        let (clear_buf_tx, clear_buf_rx) = channel(512);
+
+        let member_states = gossip::swim::load_member_states(&db.pool).await;
+
+        let members = gossip::Members(Default::default());
+
+        let swim_ctx = gossip::swim::SwimCtx {
+            metrics,
+            pool: db.pool.clone(),
+            actor_id: db.actor_id,
+            cluster_id: db.cluster_id,
+            // AFAICT this is literally only set by corrosion in tests...
+            member_id: None,
+            members: members.clone(),
+        };
+
+        let transport = gossip::transport::Transport::new_insecure(metrics, rtt_tx)
+            .context("failed to spawn client transport")?;
+
+        // Spawn the actual SWIM handler before we start accepting remote connections or making our own
+        gossip::swim::swim_loop(
+            swim_ctx,
+            corrosion::types::actor::Actor::new(
+                db.actor_id,
+                (std::net::Ipv6Addr::UNSPECIFIED, self.corrosion_gossip_port).into(),
+                db.clock.new_timestamp(),
+                db.cluster_id,
+                None,
+            ),
+            transport.clone(),
+            foca_rx,
+            broadcast_rx,
+            to_send_tx,
+            notifications_tx,
+            tripwire.clone(),
+            member_states,
+        );
+
+        gossip::swim::spawn_sender(transport, to_send_rx, tripwire.clone());
+        gossip::swim::spawn_notification_handler(
+            metrics,
+            members.clone(),
+            notifications_rx,
+            foca_tx.clone(),
+            tripwire.clone(),
+        );
+
+        let change_ctx = gossip::changes::ChangeCtx {
+            metrics,
+            pool: db.pool.clone(),
+            sub_manager: subs,
+            update_manager: updates,
+            bookie: db.bookie.clone(),
+            actor_id: db.actor_id,
+            clock: db.clock.clone(),
+            bcast_tx: broadcast_tx,
+            apply_tx,
+            clear_buf_tx,
+            // TODO: maybe make this configurable/optional, but currently the change handler will signal shutdown if it
+            // encounters a fatal DB issue
+            shutdown: shutdown.shutdown_tx(),
+        };
+
+        // TODO: make this configurable or tune the defaults once we actually see numbers in real usage
+        let change_opts = gossip::changes::ChangeOptions::default();
+
+        gossip::changes::spawn_changes_handler(
+            change_ctx.clone(),
+            change_opts.clone(),
+            changes_rx,
+            tripwire.clone(),
+        );
+
+        gossip::changes::spawn_buffered_apply(
+            change_ctx.clone(),
+            change_opts.clone(),
+            db.bookie.clone(),
+            apply_rx,
+            tripwire.clone(),
+        );
+
+        gossip::changes::spawn_buffered_cleanup(
+            change_ctx,
+            change_opts,
+            clear_buf_rx,
+            tripwire.clone(),
+        );
+
+        // Spawn a task to update the RTT state of the cluster members
+        gossip::handler::spawn_rtt_handler(members.clone(), rtt_rx, tripwire.clone());
+
+        let srv_ctx = gossip::GossipContext {
+            metrics,
+            foca_tx,
+            changes_tx,
+            sync_permits: std::sync::Arc::new(tokio::sync::Semaphore::new(3)),
+            pool: db.pool.clone(),
+            bookie: db.bookie.clone(),
+            actor_id: db.actor_id,
+            clock: db.clock.clone(),
+            cluster_id: db.cluster_id,
+        };
+
+        corrosion::gossip::handler::spawn_gossipserver_unencrypted(
+            srv_ctx,
+            tripwire,
+            (std::net::Ipv6Addr::UNSPECIFIED, self.corrosion_gossip_port).into(),
+        )
+        .context("failed to spawn gossip server")?;
 
         Ok(())
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -926,6 +926,8 @@ impl Service {
     /// Creates/open the database and machinery that allows clients to send mutation
     /// requests and/or subscription requests and be notified when a change has
     /// been made that matches their query
+    ///
+    /// Additionally, can also spawn services to gossip changes with remote nodes
     async fn spawn_corrosion_server(
         &mut self,
         config: Arc<Config>,
@@ -1248,6 +1250,19 @@ impl Service {
 
             drop(finished.send(Ok(())));
         });
+
+        // TODO: Spawn the client and server to gossip changes with other nodes if we are so configured
+
+        // let cluster_id = {
+        //     let conn = pool.read().await?;
+        //     conn.query_row(
+        //         "SELECT value FROM __corro_state WHERE key = 'cluster_id'",
+        //         [],
+        //         |row| row.get(0),
+        //     )
+        //     .optional()?
+        //     .unwrap_or_default()
+        // };
 
         Ok(())
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1043,7 +1043,7 @@ impl Service {
         let subs = types::pubsub::SubsManager::default();
         let updates = self
             .corrosion_gossip_enable
-            .then(|| types::updates::UpdatesManager::default());
+            .then(types::updates::UpdatesManager::default);
 
         let btx = corrosion::persistent::mutator::BroadcastingTransactor::new(
             db.actor_id,

--- a/tests/provider_k8s.rs
+++ b/tests/provider_k8s.rs
@@ -570,9 +570,10 @@ async fn applies_changes() {
         db.pool.clone(),
         subs.clone(),
         None,
-    )
-    .await
-    .expect("failed to create broadcaster");
+        db.bookie,
+        db.booked,
+        None,
+    );
 
     let mut pusher = Pusher {
         state,


### PR DESCRIPTION
This adds the initial version of corrosion gossip, ported from the upstream corrosion agent. This is mostly just a copy, other than changing the metrics implementation and removing/modifying some metrics and tracing and the usual lints/formatting. I've done no testing of this code, nor did I port over any unit/integration tests that exercise it as this PR was already extremely massive and I would rather do the testing in a follow up PR.